### PR TITLE
Fix Investment.search() to not include Aportacions

### DIFF
--- a/som_generationkwh/investment.py
+++ b/som_generationkwh/investment.py
@@ -1989,7 +1989,7 @@ class InvestmentProvider(ErpWrapper):
     def effectiveForMember(self, member, first_date, last_date, emission_type=None, emission_code=None):
         Investment = self.erp.pool.get('generationkwh.investment')
         return Investment.member_has_effective(self.cursor, self.uid,
-            member, first_date, last_date, emisson_type, emission_code, self.context)
+            member, first_date, last_date, emission_type, emission_code, self.context)
 
 
 GenerationkwhInvestment()

--- a/som_generationkwh/investment.py
+++ b/som_generationkwh/investment.py
@@ -573,7 +573,7 @@ class GenerationkwhInvestment(osv.osv):
 
     def pending_amortization_summary(self, cursor, uid, current_date, ids=None):
 
-        inv_ids = ids or self.search(cursor, uid, [], order='id')
+        inv_ids = ids or self.search(cursor, uid, [('emission_id.type','=','genkwh')], order='id')
         invs = self.read(cursor, uid, inv_ids, [
             'purchase_date',
             'amortized_amount',
@@ -645,7 +645,7 @@ class GenerationkwhInvestment(osv.osv):
 
         #obtenir total accions inverions
         total_dayshares_year = 1
-        list_inv_id = self.search(cursor, uid, [('member_id','=',member_id)])
+        list_inv_id = self.search(cursor, uid, [('member_id','=',member_id), ('emission_id.type','=','genkwh')])
         for inv_id in list_inv_id:
             inv_obj = self.read(cursor, uid, inv_id, ['first_effective_date','last_effective_date','nshares', 'name'])
             if inv_obj['first_effective_date']:
@@ -665,7 +665,7 @@ class GenerationkwhInvestment(osv.osv):
         amortization_ids = []
         amortization_errors = []
 
-        investment_ids = ids or self.search(cursor, uid, [], order='id')
+        investment_ids = ids or self.search(cursor, uid, [('emission_id.type','=','genkwh')], order='id')
         investments = self.read(cursor, uid, investment_ids, [
             'purchase_date',
             'amortized_amount',

--- a/som_generationkwh/tests/investment_tests.py
+++ b/som_generationkwh/tests/investment_tests.py
@@ -1695,5 +1695,23 @@ class InvestmentTests(testing.OOTestCase):
 
             self.assertFalse(has_effectives)
 
+    def test__pending_amortization_summary__manyAmortizationsSameInvestment(self):
+        with Transaction().start(self.database) as txn:
+            cursor = txn.cursor
+            uid = txn.user
+            inv_id = self.IrModelData.get_object_reference(
+                        cursor, uid, 'som_generationkwh', 'genkwh_0002'
+                        )[1]
+
+            self.assertEqual((2, 80),
+                self.Investment.pending_amortization_summary(cursor, uid, '2022-11-20', [inv_id]))
+
+    def test__pending_amortization_summary__allInvestments(self):
+        with Transaction().start(self.database) as txn:
+            cursor = txn.cursor
+            uid = txn.user
+
+            self.assertEqual((4, 120),
+                self.Investment.pending_amortization_summary(cursor, uid, '2022-11-20'))
 
 # vim: et ts=4 sw=4

--- a/som_generationkwh/wizard/wizard_investment_amortization.py
+++ b/som_generationkwh/wizard/wizard_investment_amortization.py
@@ -55,7 +55,7 @@ class WizardInvestmentAmortization(osv.osv_memory):
         current_date =  wiz.date_end
         investment_ids = context.get('active_ids', [])
         if context.get('search_all'):
-            investment_ids = Investment.search(cursor, uid, [('active', '=', True)])
+            investment_ids = Investment.search(cursor, uid, [('active', '=', True),('emission_id.type','=','genkwh')])
 
         limit_date = date.today() + timedelta(days=31)
         if isodate(current_date) > limit_date:
@@ -101,7 +101,7 @@ class WizardInvestmentAmortization(osv.osv_memory):
         amortized_invoice_errors = []
         investment_ids = context.get('active_ids', [])
         if context.get('search_all'):
-            investment_ids = Investment.search(cursor, uid, [('active', '=', True)])
+            investment_ids = Investment.search(cursor, uid, [('active', '=', True),('emission_id.type','=','genkwh')])
 
         amortized_invoice_ids, amortized_invoice_errors = Investment.amortize(cursor, uid, current_date, investment_ids, context)
 


### PR DESCRIPTION
Hi havia varis llocs on es feia un Investment.search() i obtenia també Aportacions. En els llocs on és necessari els dos, s'afegeix un paràmetre. En els que només és Generation, es filtra per emission_id.type.

