### PR TITLE
FIX timeout report de retencio d'irpf sobre el rendiment de GenerationkWh

### DIFF
--- a/som_generationkwh/report/report_retencions_gkwh.mako
+++ b/som_generationkwh/report/report_retencions_gkwh.mako
@@ -58,10 +58,10 @@
     </div>
     <br/>
     <h1 class="title">
-      ${_("Informació fiscal")}
+      ${_(u"Informació fiscal")}
     </h1>
     <h2 class="subtitle">
-      ${_("Comunicat de rendiments per a la declaració de renda")} ${data['year']}
+      ${_(u"Comunicat de rendiments per a la declaració de renda")} ${data['year']}
     </h2>
     <hr />
     <table>
@@ -74,7 +74,7 @@
         <td class="text">${data['year']}</td>
       </tr>
       <tr>
-        <td class="label">${_("Tipus d'aportació")}:</td>
+        <td class="label">${_(u"Tipus d'aportació")}:</td>
             <td class="text">${_("Generation kWh")}</td>
       </tr>
     </table>
@@ -96,7 +96,7 @@
         <td class="text">${formatLang(data['estalvi'], monetary=True)}</td>
       </tr>
       <tr>
-        <td class="label">${_("19% Retenció sobre l'estalvi")}:</td>
+        <td class="label">${_(u"19% Retenció sobre l'estalvi")}:</td>
         <td class="text">${formatLang(data['retencio'], monetary=True)}</td>
       </tr>
     </table>

--- a/som_generationkwh/report/report_retencions_gkwh.mako
+++ b/som_generationkwh/report/report_retencions_gkwh.mako
@@ -1,6 +1,4 @@
 <%
-    import logging
-    logger = logging.getLogger('openerp')
     report = objects[0]
     data = report.generationkwh_amortization_data()
 %>
@@ -48,22 +46,22 @@
 
     %for investment in objects :
     <%
-    setLang(data.language)
+    setLang(data['language'])
 
     %>
      <img  style="float: left; position: fixed; z-index:-1; margin-top: -10px;" src="${addons_path}/som_inversions/report/logo.jpg" width="150" height="150"/>
     <div class="logo_footer">
-     <span style="font-weight: bold;">${data.partner_name}</span><br/>
-        ${_(u"CIF:")} ${data.partner_vat.replace('ES','')} <br />
-        ${_(u"Domicili:")} ${data.address_street} ${data.address_zip} - ${data.address_city}<br/>
-        ${_(u"Adreça electrònica:")} ${data.address_email}<br/>
+     <span style="font-weight: bold;">${data['partner_name']}</span><br/>
+        ${_(u"CIF:")} ${data['partner_vat'].replace('ES','')} <br />
+        ${_(u"Domicili:")} ${data['address_street']} ${data['address_zip']} - ${data['address_city']}<br/>
+        ${_(u"Adreça electrònica:")} ${data['address_email']}<br/>
     </div>
     <br/>
     <h1 class="title">
       ${_("Informació fiscal")}
     </h1>
     <h2 class="subtitle">
-      ${_("Comunicat de rendiments per a la declaració de renda")} ${data.year}
+      ${_("Comunicat de rendiments per a la declaració de renda")} ${data['year']}
     </h2>
     <hr />
     <table>
@@ -73,7 +71,7 @@
       </tr>
       <tr>
         <td class="label">${_("Exercici")}:</td>
-        <td class="text">${data.year}</td>
+        <td class="text">${data['year']}</td>
       </tr>
       <tr>
         <td class="label">${_("Tipus d'aportació")}:</td>
@@ -84,22 +82,22 @@
     <table>
       <tr>
         <td class="label">${_("Titular")}:</td>
-        <td class="text">${data.member_name}</td>
+        <td class="text">${data['member_name']}</td>
       </tr>
       <tr>
         <td class="label">${_("NIF titular")}:</td>
-        <td class="text">${data.member_vat}</td>
+        <td class="text">${data['member_vat']}</td>
       </tr>
     </table>
     <hr/>
     <table>
       <tr>
         <td class="label">${_("Estalvi")}:</td>
-        <td class="text">${formatLang(data.estalvi, monetary=True)}</td>
+        <td class="text">${formatLang(data['estalvi'], monetary=True)}</td>
       </tr>
       <tr>
         <td class="label">${_("19% Retenció sobre l'estalvi")}:</td>
-        <td class="text">${formatLang(data.retencio, monetary=True)}</td>
+        <td class="text">${formatLang(data['retencio'], monetary=True)}</td>
       </tr>
     </table>
     %endfor

--- a/som_generationkwh/report/report_retencions_gkwh.py
+++ b/som_generationkwh/report/report_retencions_gkwh.py
@@ -51,9 +51,6 @@ class GenerationkwhInvestment(osv.osv):
         if year is None:
             raise Exception("Year must have a value")
 
-    def generationkwh_amortization_data_as_dict(self, cursor, uid, ids):
-        return dict(self.investmentAmortization_notificationData(cursor, uid, ids))
-
     def generationkwh_amortization_data(self, cursor, uid, ids):
 
         if not ids:

--- a/som_generationkwh/sql/genkwh_savings_between_dates_for_partner.sql
+++ b/som_generationkwh/sql/genkwh_savings_between_dates_for_partner.sql
@@ -1,0 +1,7 @@
+SELECT gkwh_owner.owner_id AS partner_id, par.vat as vat, SUM(gkwh_owner.saving_gkw_amount) as amount
+FROM generationkwh_invoice_line_owner gkwh_owner
+INNER JOIN giscedata_facturacio_factura f ON f.id=gkwh_owner.factura_id
+INNER JOIN account_invoice i ON i.id=f.invoice_id
+INNER JOIN res_partner par ON par.id = gkwh_owner.owner_id
+WHERE partner_id = %(partner_id)s AND i.date_invoice BETWEEN %(start)s AND %(end)s
+GROUP BY gkwh_owner.owner_id, par.vat

--- a/som_generationkwh/sql/genkwh_savings_between_dates_for_partner.sql
+++ b/som_generationkwh/sql/genkwh_savings_between_dates_for_partner.sql
@@ -1,7 +1,0 @@
-SELECT gkwh_owner.owner_id AS partner_id, par.vat as vat, SUM(gkwh_owner.saving_gkw_amount) as amount
-FROM generationkwh_invoice_line_owner gkwh_owner
-INNER JOIN giscedata_facturacio_factura f ON f.id=gkwh_owner.factura_id
-INNER JOIN account_invoice i ON i.id=f.invoice_id
-INNER JOIN res_partner par ON par.id = gkwh_owner.owner_id
-WHERE partner_id = %(partner_id)s AND i.date_invoice BETWEEN %(start)s AND %(end)s
-GROUP BY gkwh_owner.owner_id, par.vat


### PR DESCRIPTION
# Objectiu
Reduïr el temps en generar-se el report de retencio d'irpf sobre el rendiment de GenerationkWh 
# Comportament antic
-  El report triga en quasi tots els casos, a producció, més de 180 segons en generar-se i el worker que de render acaba matant la tasca.
# Nou comportament
- En comptes de fer servir la funció ```get_irpf_amounts```, es fa servir ```get_total_saving_partner``` la qual és molt més lleugera de processar
- Update: s'utilitza una sentencia SQL