### PR TITLE
Afegir opció d'enviar correu a la baixa de sòcia

### DIFF
--- a/som_generationkwh/__terp__.py
+++ b/som_generationkwh/__terp__.py
@@ -37,6 +37,7 @@
     "wizard/wizard_investment_transfer.xml",
     "wizard/wizard_aeat193_from_gkwh_invoices_view.xml",
     "wizard/wizard_send_retencio_estalvi_to_members.xml",
+    "wizard/wizard_baixa_soci.xml",
     "investment_view.xml",
     "assignment_view.xml",
     "somenergia_soci_view.xml",

--- a/som_generationkwh/security/ir.model.access.csv
+++ b/som_generationkwh/security/ir.model.access.csv
@@ -88,3 +88,4 @@ id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 "access_wizard_aeat193_from_gkwh_invoices_w","wizard.aeat193.from.gkwh.invoices","model_wizard_aeat193_from_gkwh_invoices","som_generationkwh.group_som_generationkwh_w",1,1,1,0
 "access_send_retencio_estalvi_to_members_wizard_rcwd","send.retencio.estalvi.to.members.wizard","model_send_retencio_estalvi_to_members_wizard","base.group_erp_manager",1,1,1,1
 "access_send_retencio_estalvi_to_members_wizard_rcwd","send.retencio.estalvi.to.members.wizard","model_send_retencio_estalvi_to_members_wizard","base.group_system",1,1,1,1
+"access_wizard_baixa_soci_rcwd","wizard.baixa.soci","model_wizard_baixa_soci","base.group_partner_manager",1,1,1,1

--- a/som_generationkwh/somenergia_soci.py
+++ b/som_generationkwh/somenergia_soci.py
@@ -158,7 +158,7 @@ class SomenergiaSoci(osv.osv):
 
         if baixa:
             raise osv.except_osv(_('El soci no pot ser donat de baixa!'),
-                                 _('Ja ha estat donat de baixa baixa anteriorment!'))
+                                 _('Ja ha estat donat de baixa anteriorment!'))
 
         gen_invest = invest_obj.search(cursor, uid, [('member_id', '=', member_id),
                                                      ('emission_id', '=', 1),
@@ -203,6 +203,8 @@ class SomenergiaSoci(osv.osv):
                                                 'data_baixa_soci': today,
                                                 'comment': comment })
         delete_rel(cursor, uid, soci_category_id, res_partner_id)
+
+        return True
 
 
     _columns = {

--- a/som_generationkwh/somenergia_soci_data.xml
+++ b/som_generationkwh/somenergia_soci_data.xml
@@ -5,5 +5,90 @@
             <field name="version_start_date">2016-03-01</field>
             <field name="kwh">170</field>
         </record>
+
+         <!-- Template de baixa de socis- -->
+        <record model="poweremail.templates" id="email_baixa_soci">
+            <field name="name">Email de notificació de baixa d'una sòcia</field>
+            <field name="object_name" model="ir.model" search="[('model', '=', 'somenergia.soci')]"/>
+            <field eval="0" name="save_to_drafts"/>
+            <field name="model_int_name">somenergia.soci</field>
+            <field name="def_to">${object.partner_id.address[0].email}</field>
+            <field eval="0" name="auto_email"/>
+            <field eval="0" name="single_email"/>
+            <field eval="0" name="use_sign"/>
+            <field name="def_subject">Confirmació baixa persona sòcia / Confirmación baja persona socia</field>
+            <field name="template_language">mako</field>
+            <field eval="0" name="send_on_create"/>
+            <field name="lang"/>
+            <field eval="0" name="send_on_write"/>
+            <field name="def_bcc">support.17062.b8d9f4469fa4d856@helpscout.net</field>
+            <field name="enforce_from_account" model="poweremail.core_accounts" search="[('name','=', 'Info Som Energia')]"/>
+            <field name="def_body_text"><![CDATA[<!doctype html>
+                <html>
+<head><meta charset='utf8'></head><body>
+<%
+from mako.template import Template
+def render(text_to_render, object_):
+    templ = Template(text_to_render)
+    return templ.render_unicode(
+        object=object_,
+        format_exceptions=True
+    )
+t_obj = object.pool.get('poweremail.templates')
+md_obj = object.pool.get('ir.model.data')
+template_id = md_obj.get_object_reference(
+                    object._cr, object._uid,  'som_poweremail_common_templates', 'common_template_legal_footer'
+                )[1]
+text_legal = render(t_obj.read(
+    object._cr, object._uid, [template_id], ['def_body_text'])[0]['def_body_text'],
+    object
+)
+%>
+% if object.partner_id.lang != "es_ES":
+<br>
+Hola,<br>
+<br>
+Ens posem amb contacte amb tu per informar-te que hem tramitat correctament la teva baixa de persona sòcia.<br>
+<br>
+T’agraïm el temps que has passat amb nosaltres ajudant-nos a canviar el model energètic actual.<br>
+<br>
+Desitgem que ens retrobem en un futur.<br>
+<br>
+Salut i bona energia!<br>
+<br>
+Equip de Som Energia<br>
+<a href="www.somenergia.coop/ca">www.somenergia.coop</a>
+info@somenergia.coop
+<a href="http://ca.support.somenergia.coop/article/470-com-puc-contactar-amb-la-cooperativa-mail-telefon-etc">Contactar amb Som Energia</a>
+% endif
+
+% if object.partner_id.lang != "ca_ES" and object.partner_id.lang != "es_ES":
+----------------------------------------------------------------------------------------------------
+% endif
+
+% if object.partner_id.lang != "ca_ES":
+<br>
+Hola,<br>
+<br>
+Nos ponemos en contacto contigo para informarte que hemos tramitado correctamente tu baja de persona socia.<br>
+<br>
+Te agradecemos el tiempo que has pasado con nosotros ayudándonos a cambiar el modelo energético actual.<br>
+<br>
+Deseamos reencontrarnos en un futuro.<br>
+<br>
+Salud y buena energía!<br>
+<br>
+Equipo de Som Energia<br>
+<a href="www.somenergia.coop/ca">www.somenergia.coop</a>
+info@somenergia.coop
+<a href="https://es.support.somenergia.coop/article/471-como-puedo-contactar-con-la-cooperativa-mail-telefono-etc">Contactar con Som Energia</a>
+% endif
+${text_legal}
+</body>
+</html>
+
+                ]]></field>
+        </record>
+
     </data>
 </openerp>

--- a/som_generationkwh/somenergia_soci_view.xml
+++ b/som_generationkwh/somenergia_soci_view.xml
@@ -66,23 +66,5 @@
             <field name="view_id" ref="view_generationkwh_kwh_per_share_tree"/>
         </record>
         <menuitem action="action_generationkwh_kwh_per_share_tree" id="menu_generationkwh_kwh_per_share_tree" parent="menu_gkwh_base"/>
-
-        <record id="view_partner_form_soci_generationkwh_fields" model="ir.ui.view">
-            <field name="name">somenergia.soci.form</field>
-            <field name="model">somenergia.soci</field>
-            <field name="type">form</field>
-            <field name="inherit_id" ref="som_partner_account.view_partner_form_soci_fields"/>
-            <field name="priority" eval="20"/>
-            <field name="arch" type="xml">
-                <data>
-                   <xpath expr="//form[@string='Partners']/group/field[@name='supplier']" position="after">
-                        <group colspan="2" attrs="{'invisible': [('baixa','=', True)]}">
-                            <button name="verifica_baixa_soci" string="Baixa soci" type="object" icon="gtk-execute"/>
-                        </group>
-                    </xpath>
-                </data>
-            </field>
-        </record>
-
     </data>
 </openerp>

--- a/som_generationkwh/tests/__init__.py
+++ b/som_generationkwh/tests/__init__.py
@@ -2,3 +2,4 @@ from emission_tests import *
 from investment_tests import *
 from partner_tests import *
 from somenergia_soci_tests import *
+from test_wizard_baixa_soci import *

--- a/som_generationkwh/tests/generation_data_demo.xml
+++ b/som_generationkwh/tests/generation_data_demo.xml
@@ -280,6 +280,17 @@
             <field name="state">approved</field>
             <field name="smtpport">587</field>
         </record>
+
+        <record model="poweremail.core_accounts" id="info_som_mail_account">
+            <field name="email_id">info@somenergia.coop</field>
+            <field name="company">yes</field>
+            <field name="smtpserver">smtp.mandrillapp.com</field>
+            <field name="send_pref">html</field>
+            <field name="name">Info Som Energia</field>
+            <field name="state">approved</field>
+            <field name="smtpport">587</field>
+        </record>
+
         <record id="res_partner_inversor1" model="res.partner">
             <field name="bank_inversions" ref="partner_bank1"></field>
         </record>

--- a/som_generationkwh/tests/test_wizard_baixa_soci.py
+++ b/som_generationkwh/tests/test_wizard_baixa_soci.py
@@ -1,0 +1,97 @@
+# -*- coding: utf-8 -*-
+from destral import testing
+from destral.transaction import Transaction
+from osv import osv
+from datetime import datetime
+import poweremail
+import mock
+
+
+class TestWizardBaixaSoci(testing.OOTestCase):
+    def setUp(self):
+        self.txn = Transaction().start(self.database)
+        self.cursor = self.txn.cursor
+        self.uid = self.txn.user
+        self.Investment = self.openerp.pool.get('generationkwh.investment')
+        self.IrModelData = self.openerp.pool.get('ir.model.data')
+        self.Soci = self.openerp.pool.get('somenergia.soci')
+        self.WizardBaixaSoci = self.openerp.pool.get('wizard.baixa.soci')
+        self.AccountObj = self.openerp.pool.get('poweremail.core_accounts')
+
+    def tearDown(self):
+        self.txn.stop()
+
+    def test__baixa_soci__allowed(self):
+        member_id = self.IrModelData.get_object_reference(
+            self.cursor, self.uid, 'som_generationkwh', 'soci_0003' 
+        )[1]
+        self.Soci.write(self.cursor, self.uid, [member_id], {'baixa': False, 'data_baixa_soci': None})
+        context = {'active_ids':[member_id]}
+
+        wiz_id = self.WizardBaixaSoci.create(self.cursor, self.uid, {'info':''}, context=context)
+        self.WizardBaixaSoci.baixa_soci(self.cursor, self.uid, wiz_id, context=context, send_mail=False)
+
+        baixa = self.Soci.read(self.cursor, self.uid, member_id, ['baixa'])['baixa']
+        self.assertTrue(baixa)
+
+    def test__baixa_soci__notAllowed(self):
+        member_id = self.IrModelData.get_object_reference(
+            self.cursor, self.uid, 'som_generationkwh', 'soci_0001' 
+        )[1]
+        self.Soci.write(self.cursor, self.uid, [member_id], {'baixa': False, 'data_baixa_soci': None})
+        context = {'active_ids':[member_id]}
+
+        wiz_id = self.WizardBaixaSoci.create(self.cursor, self.uid, {'info':''}, context=context)
+        self.WizardBaixaSoci.baixa_soci(self.cursor, self.uid, wiz_id, context=context, send_mail=False)
+
+        baixa = self.Soci.read(self.cursor, self.uid, member_id, ['baixa'])['baixa']
+        self.assertFalse(baixa)
+
+    @mock.patch("poweremail.poweremail_send_wizard.poweremail_send_wizard.send_mail")
+    def test__baixa_soci_and_send_mail__allowed(self, mocked_send_mail):
+        member_id = self.IrModelData.get_object_reference(
+            self.cursor, self.uid, 'som_generationkwh', 'soci_0003' 
+        )[1]
+        self.Soci.write(self.cursor, self.uid, [member_id], {'baixa': False, 'data_baixa_soci': None})
+        context = {'active_ids':[member_id]}
+
+        wiz_id = self.WizardBaixaSoci.create(self.cursor, self.uid, {'info':''}, context=context)
+        self.WizardBaixaSoci.baixa_soci(self.cursor, self.uid, wiz_id, context=context, send_mail=True)
+
+        baixa = self.Soci.read(self.cursor, self.uid, member_id, ['baixa'])['baixa']
+        self.assertTrue(baixa)
+
+        template_id = self.IrModelData.get_object_reference(
+            self.cursor, self.uid, 'som_generationkwh', 'email_baixa_soci'
+        )[1]
+        
+        email_from = self.AccountObj.search(self.cursor, self.uid, [('name', '=', 'Info Som Energia')])[0]
+        
+        expected_ctx = {
+                'active_ids': [member_id],
+                'active_id': member_id,
+                'template_id': template_id,
+                'src_model': 'somenergia.soci',
+                'src_rec_ids': [member_id],
+                'from': email_from,
+                'state': 'single',
+                'priority': '0',
+            }
+
+        mocked_send_mail.assert_called_with(self.cursor, self.uid, mock.ANY, expected_ctx)
+    
+    @mock.patch("poweremail.poweremail_send_wizard.poweremail_send_wizard.send_mail")
+    def test__baixa_soci_and_send_mail__notAllowed(self, mocked_send_mail):
+        member_id = self.IrModelData.get_object_reference(
+            self.cursor, self.uid, 'som_generationkwh', 'soci_0001' 
+        )[1]
+        self.Soci.write(self.cursor, self.uid, [member_id], {'baixa': False, 'data_baixa_soci': None})
+
+        context = {'active_ids':[member_id]}
+
+        wiz_id = self.WizardBaixaSoci.create(self.cursor, self.uid, {'info':''}, context=context)
+        self.WizardBaixaSoci.baixa_soci_and_send_mail(self.cursor, self.uid, wiz_id, context=context)
+
+        baixa = self.Soci.read(self.cursor, self.uid, member_id, ['baixa'])['baixa']
+        self.assertFalse(baixa)
+        mocked_send_mail.assert_not_called()

--- a/som_generationkwh/wizard/__init__.py
+++ b/som_generationkwh/wizard/__init__.py
@@ -8,3 +8,4 @@ import wizard_investment_divest
 import wizard_investment_transfer
 import wizard_aeat193_from_gkwh_invoices
 import wizard_send_retencio_estalvi_to_members
+import wizard_baixa_soci

--- a/som_generationkwh/wizard/wizard_baixa_soci.py
+++ b/som_generationkwh/wizard/wizard_baixa_soci.py
@@ -32,7 +32,7 @@ class WizardBaixaSoci(osv.osv):
         else:
             if send_mail:
                 self.send_mail(cursor, uid, soci_id[0])
-                self.write(cursor, uid, ids, {'state':'ok'})
+            self.write(cursor, uid, ids, {'state':'ok'})
 
 
     def baixa_soci_and_send_mail(self, cursor, uid, ids, context=None):

--- a/som_generationkwh/wizard/wizard_baixa_soci.py
+++ b/som_generationkwh/wizard/wizard_baixa_soci.py
@@ -1,0 +1,94 @@
+# -*- coding: utf-8 -*-
+
+from osv import osv, fields
+from tools.translate import _
+import logging
+
+class WizardBaixaSoci(osv.osv):
+
+    _name = 'wizard.baixa.soci'
+    _columns = {
+        'state': fields.char('State', size=16),
+        'info': fields.text('Info')
+    }
+    _defaults = {
+        'state': 'init'
+    }
+
+    def baixa_soci(self, cursor, uid, ids, context=None, send_mail=False):
+        soci_obj = self.pool.get('somenergia.soci')
+        soci_id = context['active_ids']
+
+        if not isinstance(soci_id, list):
+            soci_id = [soci_id]
+        if len(soci_id) != 1:
+            raise "Has de seleccionar un sol soci"
+
+        try:
+            soci_obj.verifica_baixa_soci(cursor, uid, soci_id[0], context)
+        except osv.except_osv as e:
+            self.write(cursor, uid, ids, {'state':'error',
+                                          'info': e.message})
+        else:
+            if send_mail:
+                self.send_mail(cursor, uid, soci_id[0])
+                self.write(cursor, uid, ids, {'state':'ok'})
+
+
+    def baixa_soci_and_send_mail(self, cursor, uid, ids, context=None):
+        self.baixa_soci(cursor, uid, ids, context, send_mail=True)
+
+    def send_mail(self, cursor, uid, soci_id, context=None):
+        ir_model_data = self.pool.get('ir.model.data')
+        account_obj = self.pool.get('poweremail.core_accounts')
+        power_email_tmpl_obj = self.pool.get('poweremail.templates')
+
+        template_id = ir_model_data.get_object_reference(
+            cursor, uid, 'som_generationkwh', 'email_baixa_soci'
+        )[1]
+        template = power_email_tmpl_obj.read(cursor, uid, template_id)
+
+        email_from = False
+        template_name = 'Info Som Energia'
+
+        if template.get(template_name, False):
+            email_from = template.get('enforce_from_account')[0]
+
+        if not email_from:
+            email_from = account_obj.search(cursor, uid, [('name', '=', template_name)])[0]
+
+        email_params = dict({
+            'email_from': email_from,
+            'template_id': template_id
+        })
+
+        logger = logging.getLogger('openerp.poweremail')
+
+        try:
+            wiz_send_obj = self.pool.get('poweremail.send.wizard')
+            ctx = {
+                'active_ids': [soci_id],
+                'active_id': soci_id,
+                'template_id': email_params['template_id'],
+                'src_model': 'somenergia.soci',
+                'src_rec_ids': [soci_id],
+                'from': email_params['email_from'],
+                'state': 'single',
+                'priority': '0',
+            }
+
+            params = {'state': 'single', 'priority': '0', 'from': ctx['from']}
+            wiz_id = wiz_send_obj.create(cursor, uid, params, ctx)
+            return wiz_send_obj.send_mail(cursor, uid, [wiz_id], ctx)
+
+        except Exception as e:
+            logger.info(
+                'ERROR sending email to member {soci_id}: {exc}'.format(
+                    soci_id=soci_id,
+                    exc=e
+                )
+            )
+
+
+WizardBaixaSoci()
+

--- a/som_generationkwh/wizard/wizard_baixa_soci.xml
+++ b/som_generationkwh/wizard/wizard_baixa_soci.xml
@@ -43,7 +43,7 @@
 
 	
 	<record model="ir.actions.act_window" id="action_wizard_confirm_soci_baixa">
-	    <field name="name">Baixa de soci</field>
+	    <field name="name">Baixa de sòcia</field>
 	    <field name="res_model">wizard.baixa.soci</field>
 	    <field name="view_type">form</field>
 	    <field name="view_mode">form</field>
@@ -53,7 +53,7 @@
 
 	<record id="value_wizard_confirm_soci_baixa" model="ir.values">
             <field name="object" eval="1"/>
-            <field name="name">Baixa de soci</field>
+            <field name="name">Baixa de sòcia</field>
             <field name="key2">client_action_multi</field>
             <field name="key">action</field>
             <field name="model">somenergia.soci</field>

--- a/som_generationkwh/wizard/wizard_baixa_soci.xml
+++ b/som_generationkwh/wizard/wizard_baixa_soci.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0"?>
+<openerp>
+    <data noupdate="0">
+	<record model="ir.ui.view" id="view_wizard_confirm_soci_baixa">
+        <field name="name">wizard.soci.baixa.form</field>
+        <field name="model">wizard.baixa.soci</field>
+        <field name="type">form</field>
+        <field name="arch" type="xml" >
+            <form string="Add a comment">
+                <field name="state" invisible="1"/>
+                <group attrs="{'invisible': [('state', '!=', 'init')]}">
+                    <group colspan="4" >
+                        <label string="ATENCIÓ!" colspan="4" />
+                        <label string="Aquesta acció donarà de baixa el soci seleccionat" colspan="4" />
+                    </group>
+                    <group colspan="4" >
+                        <group colspan="4" >
+                            <button string="Baixa" type="object" name="baixa_soci" icon="gtk-yes" confirm="Estas segur?" colspan="4"/>
+                            <button string="Baixa i enviament de correu" type="object" name="baixa_soci_and_send_mail" icon="gtk-yes" confirm="Estas segur?" colspan="4"/>
+                        </group>
+                    <separator colspan="4" />
+                        <group colspan="4">
+                            <button string="Cancel·lar" special="cancel" type="object" icon="gtk-cancel" colspan="4"/>
+                        </group>
+                    </group>
+                </group>
+
+                <group attrs="{'invisible': [('state', '!=', 'ok')]}">
+                    <label colspan="4" string="La baixa s'ha efectuat correctament"/>
+                    <separator colspan="4" />
+                    <button string="Tancar" special="cancel" type="object"/>
+                </group>
+
+                <group attrs="{'invisible': [('state', '!=', 'error')]}">  
+                    <label colspan="4" string="No s'ha pogut efectuar la baixa"/>
+                    <separator colspan="4" />
+                    <field name="info" nolabel="1" readonly="1" colspan="4"/>
+                    <button string="Tancar" special="cancel" type="object" colspan="4"/>
+                </group>
+            </form>
+        </field>
+    </record> 
+
+	
+	<record model="ir.actions.act_window" id="action_wizard_confirm_soci_baixa">
+	    <field name="name">Baixa de soci</field>
+	    <field name="res_model">wizard.baixa.soci</field>
+	    <field name="view_type">form</field>
+	    <field name="view_mode">form</field>
+	    <field name="target">new</field>
+	    <field name="view_id" ref="view_wizard_confirm_soci_baixa"/>
+	</record>
+
+	<record id="value_wizard_confirm_soci_baixa" model="ir.values">
+            <field name="object" eval="1"/>
+            <field name="name">Baixa de soci</field>
+            <field name="key2">client_action_multi</field>
+            <field name="key">action</field>
+            <field name="model">somenergia.soci</field>
+            <field name="value" eval="'ir.actions.act_window,'+str(ref('action_wizard_confirm_soci_baixa'))" />
+        </record>
+    </data>
+</openerp>


### PR DESCRIPTION
## Objectius

- Afegir la opció d'enviar el email de confirmació de baixa de sòcia

## Comportament antic

Botó que comprovava i efectuava la baixa de la persona sòcia.

## Comportament nou

S'ha modificat el botó, ara passa a ser una acció amb les dues opcions.
![baixa_v2](https://user-images.githubusercontent.com/12842454/85426743-2b488800-b57b-11ea-9dad-13ac0914477d.gif)

## Checklist

- [X] Test code
- [ ] Documentation (link to [PowERP docs](https://github.com/gisce/powerp-docs) repo)
- [X] Si se modifica alguna vista poner una captura indicando qué se modifica
- [ ] Si se modifica un report adjuntar el report
- [ ] Migration data
