### PR TITLE
Arxiva els emails de les sòcies d'una llista de Mailchimp

### DIFF
--- a/som_generationkwh/requirements.txt
+++ b/som_generationkwh/requirements.txt
@@ -1,7 +1,7 @@
+https://github.com/mailchimp/mailchimp-marketing-python/archive/master.zip
 # libfacturacioatr
 numpy
 yamlns
 plantmeter
 python-dateutil
 freezegun
--e git://github.com/mailchimp/mailchimp-marketing-python.git#egg=mailchimp-marketing-python

--- a/som_generationkwh/requirements.txt
+++ b/som_generationkwh/requirements.txt
@@ -4,4 +4,4 @@ yamlns
 plantmeter
 python-dateutil
 freezegun
--e git://github.com/mailchimp/mailchimp-marketing-python.git@master#egg=mailchimp-marketing-python
+-e git://github.com/mailchimp/mailchimp-marketing-python.git#egg=mailchimp-marketing-python

--- a/som_generationkwh/requirements.txt
+++ b/som_generationkwh/requirements.txt
@@ -4,3 +4,4 @@ yamlns
 plantmeter
 python-dateutil
 freezegun
+-e git://github.com/mailchimp/mailchimp-marketing-python.git@master#egg=mailchimp-marketing-python

--- a/som_generationkwh/somenergia_soci.py
+++ b/som_generationkwh/somenergia_soci.py
@@ -135,7 +135,6 @@ class SomenergiaSoci(osv.osv):
         """
         Archive member async method
         """
-        logger = logging.getLogger('openerp.{0}.mailchimp_tasks'.format(__name__))
         return self.arxiva_socia_mailchimp(cursor, uid, ids, context=context)
 
 

--- a/som_generationkwh/somenergia_soci.py
+++ b/som_generationkwh/somenergia_soci.py
@@ -4,6 +4,9 @@ from __future__ import absolute_import
 
 from osv import osv, fields
 from tools.translate import _
+import mailchimp_marketing as MailchimpMarketing
+from tools import config
+from oorq.decorators import job
 
 from datetime import datetime, date
 
@@ -128,6 +131,36 @@ class SomenergiaSoci(osv.osv):
 
         return True
 
+    @job(queue="mailchimp_tasks")
+    def arxiva_socia_mailchimp_async(self, cursor, uid, ids, context=None):
+        """
+        Archive member async method
+        """
+        logger = logging.getLogger('openerp.{0}.mailchimp_tasks'.format(__name__))
+        return self.arxiva_socia_mailchimp(cursor, uid, ids, context=context)
+
+
+    def arxiva_socia_mailchimp(self, cursor, uid, ids, context=None):
+        if not isinstance(ids, (list, tuple)):
+            ids = [ids]
+        MAILCHIMP_CLIENT = MailchimpMarketing.Client(
+            dict(api_key=config.options.get('mailchimp_apikey'),
+                 server=config.options.get('mailchimp_server_prefix')
+            ))
+
+        conf_obj = self.pool.get('res.config')
+        res_partner_obj = self.pool.get('res.partner')
+        res_partner_address_obj = self.pool.get('res.partner.address')
+
+        list_name = conf_obj.get(
+            cursor, uid, 'mailchimp_socis_list', None)
+
+        list_id = res_partner_address_obj.get_mailchimp_list_id(list_name, MAILCHIMP_CLIENT)
+        for partner_id in self.read(cursor, uid, ids,['partner_id']):
+            address_list = res_partner_obj.read(cursor, uid, partner_id['partner_id'][0], ['address'])['address']
+            res_partner_address_obj.archieve_mail_in_list(cursor, uid, address_list, list_id, MAILCHIMP_CLIENT)
+
+
     def verifica_baixa_soci(self, cursor, uid, ids, context=None):
         # - Comprovar si té generationkwh: Existeix atribut al model generation que ho indica. Altrament es poden buscar les inversions.
         # - Comprovar si té inversions vigents: Buscar inversions vigents.
@@ -203,6 +236,8 @@ class SomenergiaSoci(osv.osv):
                                                 'data_baixa_soci': today,
                                                 'comment': comment })
         delete_rel(cursor, uid, soci_category_id, res_partner_id)
+
+        self.arxiva_socia_mailchimp_async(cursor, uid, member_id)
 
         return True
 

--- a/som_generationkwh/somenergia_soci.py
+++ b/som_generationkwh/somenergia_soci.py
@@ -4,7 +4,6 @@ from __future__ import absolute_import
 
 from osv import osv, fields
 from tools.translate import _
-import mailchimp_marketing as MailchimpMarketing
 from tools import config
 from oorq.decorators import job
 
@@ -141,6 +140,7 @@ class SomenergiaSoci(osv.osv):
 
 
     def arxiva_socia_mailchimp(self, cursor, uid, ids, context=None):
+        import mailchimp_marketing as MailchimpMarketing
         if not isinstance(ids, (list, tuple)):
             ids = [ids]
         MAILCHIMP_CLIENT = MailchimpMarketing.Client(

--- a/som_generationkwh/somenergia_soci_data.xml
+++ b/som_generationkwh/somenergia_soci_data.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <openerp>
-    <data>
+    <data noupdate="1">
         <record model="generationkwh.kwh.per.share" id="gkwh_kwh_per_share_20160301">
             <field name="version_start_date">2016-03-01</field>
             <field name="kwh">170</field>
@@ -90,5 +90,10 @@ ${text_legal}
                 ]]></field>
         </record>
 
+        <record model="res.config" id="mailchimp_socis_list">
+            <field name="name">mailchimp_socis_list</field>
+            <field name="value">Soci/a de Som Energia</field>
+            <field name="description">Nom exacte de la llista de mailchimp on es subscriuen o arxiven automàticament les sòcies en donar-se d'alta o baixa respectivament.</field>
+        </record>
     </data>
 </openerp>

--- a/som_generationkwh/tests/test_wizard_baixa_soci.py
+++ b/som_generationkwh/tests/test_wizard_baixa_soci.py
@@ -21,7 +21,8 @@ class TestWizardBaixaSoci(testing.OOTestCase):
     def tearDown(self):
         self.txn.stop()
 
-    def test__baixa_soci__allowed(self):
+    @mock.patch("som_generationkwh.somenergia_soci.SomenergiaSoci.arxiva_socia_mailchimp_async")
+    def test__baixa_soci__allowed(self, mailchimp_mock):
         member_id = self.IrModelData.get_object_reference(
             self.cursor, self.uid, 'som_generationkwh', 'soci_0003' 
         )[1]
@@ -33,6 +34,7 @@ class TestWizardBaixaSoci(testing.OOTestCase):
 
         baixa = self.Soci.read(self.cursor, self.uid, member_id, ['baixa'])['baixa']
         self.assertTrue(baixa)
+        mailchimp_mock.assert_called_with(self.cursor, self.uid, member_id)
 
     def test__baixa_soci__notAllowed(self):
         member_id = self.IrModelData.get_object_reference(
@@ -47,8 +49,9 @@ class TestWizardBaixaSoci(testing.OOTestCase):
         baixa = self.Soci.read(self.cursor, self.uid, member_id, ['baixa'])['baixa']
         self.assertFalse(baixa)
 
+    @mock.patch("som_generationkwh.somenergia_soci.SomenergiaSoci.arxiva_socia_mailchimp_async")
     @mock.patch("poweremail.poweremail_send_wizard.poweremail_send_wizard.send_mail")
-    def test__baixa_soci_and_send_mail__allowed(self, mocked_send_mail):
+    def test__baixa_soci_and_send_mail__allowed(self, mocked_send_mail, mailchimp_mock):
         member_id = self.IrModelData.get_object_reference(
             self.cursor, self.uid, 'som_generationkwh', 'soci_0003' 
         )[1]
@@ -79,6 +82,7 @@ class TestWizardBaixaSoci(testing.OOTestCase):
             }
 
         mocked_send_mail.assert_called_with(self.cursor, self.uid, mock.ANY, expected_ctx)
+        mailchimp_mock.assert_called_with(self.cursor, self.uid, member_id)
     
     @mock.patch("poweremail.poweremail_send_wizard.poweremail_send_wizard.send_mail")
     def test__baixa_soci_and_send_mail__notAllowed(self, mocked_send_mail):


### PR DESCRIPTION
## Objectius

- Arxivar els mails d'una persona sòcia d'una lista de `mailchimp` quan la sòcia es dóna de baixa.

## Comportament antic

- Inexistent

## Comportament nou

- S'arxiven de la llista de mailchimp configurada a la variable de configuració `mailchimp_socis_list` les adreces d'email de la persona sòcia quan aquesta es dóna de baixa.

## Afectacions / Migració de dades

- [X] Codi. Reiniciar servis
- [X] Actualització mòduls:
    - `som_generationkwh`

## Checklist

- [x] Test code


## Variables de configuració 
Cal afegir les variables MAILCHIMP_APIKEY i MAILCHIMP_SERVER_PREFIX a la configuració per a la connexió amb l'API de Mailchimp