### PR TITLE
Fix missign actions log

### DIFF
--- a/som_generationkwh/investment.py
+++ b/som_generationkwh/investment.py
@@ -1359,6 +1359,7 @@ class GenerationkwhInvestment(osv.osv):
                 amount = nominal_amount
 
             inv = self.state_actions(cursor, uid, id, user['name'], datetime.now(),
+                actions_log = investment['actions_log'],
                 log = investment['log'],
                 nominal_amount = nominal_amount,
                 purchase_date = investment['purchase_date'],

--- a/som_generationkwh/investment.py
+++ b/som_generationkwh/investment.py
@@ -696,6 +696,7 @@ class GenerationkwhInvestment(osv.osv):
         for inv in investments:
             investment_id = inv['id']
             invstate = InvestmentState(username, datetime.now(),
+                actions_log = inv['actions_log'],
                 log = inv['log'],
                 amortized_amount = inv['amortized_amount'],
                 purchase_date = isodate(inv['purchase_date']),
@@ -1077,6 +1078,7 @@ class GenerationkwhInvestment(osv.osv):
                 last_effective_date = old_investment['last_effective_date'],
                 order_date = old_investment['order_date'],
                 log = old_investment['log'],
+                actions_log = old_investment['actions_log'],
         )
         inv_old = InvestmentState(user['name'], datetime.now(),
                 name = old_investment['name'],
@@ -1088,6 +1090,7 @@ class GenerationkwhInvestment(osv.osv):
                 last_effective_date = old_investment['last_effective_date'],
                 order_date = old_investment['order_date'],
                 log = old_investment['log'],
+                actions_log = old_investment['actions_log'],
         )
         amount = old_investment['nshares']*gkwh.shareValue - old_investment['amortized_amount']
         to_partner_name = new_partner_id #TODO Get partner name from id
@@ -1152,6 +1155,7 @@ class GenerationkwhInvestment(osv.osv):
             signed_date = str(datetime.today().date())
 
         inv = InvestmentState(user['name'], datetime.now(),
+            actions_log = investment['actions_log'],
             log = investment['log'],
             signed_date = investment['signed_date'],
         )
@@ -1323,6 +1327,7 @@ class GenerationkwhInvestment(osv.osv):
         user = ResUser.read(cursor, uid, uid, ['name'])
 
         inv = InvestmentState(user['name'], datetime.now(),
+            actions_log = investment['actions_log'],
             log = investment['log'],
             draft = investment['draft'],
         )
@@ -1395,6 +1400,7 @@ class GenerationkwhInvestment(osv.osv):
                 amount = nominal_amount
 
             inv = InvestmentState(user['name'], datetime.now(),
+                actions_log = investment['actions_log'],
                 log = investment['log'],
                 nominal_amount = nominal_amount,
                 purchase_date = investment['purchase_date'],
@@ -1650,6 +1656,7 @@ class GenerationkwhInvestment(osv.osv):
                 ])
 
             inv = InvestmentState(user['name'], datetime.now(),
+                actions_log = investment['actions_log'],
                 log = investment['log'],
                 purchase_date = investment['purchase_date'],
                 draft = investment['draft'],
@@ -1691,6 +1698,7 @@ class GenerationkwhInvestment(osv.osv):
 
             # mark investment as canceled
             inv = InvestmentState(user['name'], datetime.now(),
+                actions_log = investment['actions_log'],
                 log = investment['log'],
                 purchase_date = investment['purchase_date'],
                 draft = investment['draft'],

--- a/som_generationkwh/investment.py
+++ b/som_generationkwh/investment.py
@@ -1139,7 +1139,7 @@ class GenerationkwhInvestment(osv.osv):
         Soci = self.pool.get('somenergia.soci')
         User = self.pool.get('res.users')
         user = User.read(cursor, uid, uid, ['name'])
-        inversio = self.read(cursor, uid, id, [
+        investment = self.read(cursor, uid, id, [
             'log',
             'draft',
             'actions_log',
@@ -1152,8 +1152,8 @@ class GenerationkwhInvestment(osv.osv):
             signed_date = str(datetime.today().date())
 
         inv = InvestmentState(user['name'], datetime.now(),
-            log = inversio['log'],
-            signed_date = inversio['signed_date'],
+            log = investment['log'],
+            signed_date = investment['signed_date'],
         )
         inv.sign(signed_date)
         self.write(cursor, uid, id, inv.erpChanges())
@@ -1314,7 +1314,7 @@ class GenerationkwhInvestment(osv.osv):
         Soci = self.pool.get('somenergia.soci')
         User = self.pool.get('res.users')
         user = User.read(cursor, uid, uid, ['name'])
-        inversio = self.read(cursor, uid, id, [
+        investment = self.read(cursor, uid, id, [
             'log',
             'draft',
             'actions_log',
@@ -1323,8 +1323,8 @@ class GenerationkwhInvestment(osv.osv):
         user = ResUser.read(cursor, uid, uid, ['name'])
 
         inv = InvestmentState(user['name'], datetime.now(),
-            log = inversio['log'],
-            draft = inversio['draft'],
+            log = investment['log'],
+            draft = investment['draft'],
         )
         inv.invoice()
         self.write(cursor, uid, id, inv.erpChanges())
@@ -1335,7 +1335,7 @@ class GenerationkwhInvestment(osv.osv):
         Emission = self.pool.get('generationkwh.emission')
         user = ResUser.read(cursor, uid, uid, ['name'])
         for id in ids:
-            inversio = self.read(cursor, uid, id, [
+            investment = self.read(cursor, uid, id, [
                 'log',
                 'actions_log',
                 'nshares',
@@ -1345,7 +1345,7 @@ class GenerationkwhInvestment(osv.osv):
                 'emission_id',
                 ])
             user = ResUser.read(cursor, uid, uid, ['name'])
-            nominal_amount = inversio['nshares']*gkwh.shareValue
+            nominal_amount = investment['nshares']*gkwh.shareValue
             if movementline_id:
                 MoveLine = self.pool.get('account.move.line')
                 moveline = ns(MoveLine.read(cursor, uid, movementline_id, []))
@@ -1354,12 +1354,12 @@ class GenerationkwhInvestment(osv.osv):
                 amount = nominal_amount
 
             inv = self.state_actions(cursor, uid, id, user['name'], datetime.now(),
-                log = inversio['log'],
+                log = investment['log'],
                 nominal_amount = nominal_amount,
-                purchase_date = inversio['purchase_date'],
-                draft = inversio['draft'],
+                purchase_date = investment['purchase_date'],
+                draft = investment['draft'],
             )
-            emission_data = Emission.read(cursor, uid, inversio['emission_id'][0], ['waiting_days', 'expiration_years'])
+            emission_data = Emission.read(cursor, uid, investment['emission_id'][0], ['waiting_days', 'expiration_years'])
             waitDays = emission_data['waiting_days']
             expirationYears = emission_data['expiration_years']
             inv.pay(
@@ -1377,7 +1377,7 @@ class GenerationkwhInvestment(osv.osv):
         AccountInvoice = self.pool.get('account.invoice')
         user = ResUser.read(cursor, uid, uid, ['name'])
         for id in ids:
-            inversio = self.read(cursor, uid, id, [
+            investment = self.read(cursor, uid, id, [
                 'log',
                 'actions_log',
                 'nshares',
@@ -1386,7 +1386,7 @@ class GenerationkwhInvestment(osv.osv):
                 'name',
             ])
             user = ResUser.read(cursor, uid, uid, ['name'])
-            nominal_amount = inversio['nshares']*gkwh.shareValue
+            nominal_amount = investment['nshares']*gkwh.shareValue
             if movementline_id:
                 MoveLine = self.pool.get('account.move.line')
                 moveline = ns(MoveLine.read(cursor, uid, movementline_id, []))
@@ -1395,10 +1395,10 @@ class GenerationkwhInvestment(osv.osv):
                 amount = nominal_amount
 
             inv = InvestmentState(user['name'], datetime.now(),
-                log = inversio['log'],
+                log = investment['log'],
                 nominal_amount = nominal_amount,
-                purchase_date = inversio['purchase_date'],
-                draft = inversio['draft'],
+                purchase_date = investment['purchase_date'],
+                draft = investment['draft'],
             )
 
             inv.unpay(
@@ -1408,7 +1408,7 @@ class GenerationkwhInvestment(osv.osv):
 
             self.write(cursor, uid, id, inv.erpChanges())
 
-            name_invoice = inversio['name'] + '-JUST'
+            name_invoice = investment['name'] + '-JUST'
             invoice_ids = AccountInvoice.search(cursor, uid, [
                 ('name', '=', name_invoice)
             ])
@@ -1641,7 +1641,7 @@ class GenerationkwhInvestment(osv.osv):
         User = self.pool.get('res.users')
         user = User.read(cursor, uid, uid, ['name'])
         for id in ids:
-            inversio = self.read(cursor, uid, id, [
+            investment = self.read(cursor, uid, id, [
                 'log',
                 'actions_log',
                 'purchase_date',
@@ -1650,10 +1650,10 @@ class GenerationkwhInvestment(osv.osv):
                 ])
 
             inv = InvestmentState(user['name'], datetime.now(),
-                log = inversio['log'],
-                purchase_date = inversio['purchase_date'],
-                draft = inversio['draft'],
-                active = inversio['active']
+                log = investment['log'],
+                purchase_date = investment['purchase_date'],
+                draft = investment['draft'],
+                active = investment['active']
             )
             inv.cancel()
             self.write(cursor, uid, id, inv.erpChanges())
@@ -1665,7 +1665,7 @@ class GenerationkwhInvestment(osv.osv):
         invoice_ids = []
         invoice_errors = []
         for id in ids:
-            inversio = self.read(cursor, uid, id, [
+            investment = self.read(cursor, uid, id, [
                 'name',
                 'id',
                 'log',
@@ -1678,7 +1678,7 @@ class GenerationkwhInvestment(osv.osv):
             # recover the investment's initial payment invoice
             invoice_name = '%s-JUST' % (
                 # TODO: Remove the GENKWHID stuff when fully migrated, error instead
-                inversio['name'] or 'GENKWHID{}'.format(inversio['id']),
+                investment['name'] or 'GENKWHID{}'.format(investment['id']),
             )
 
             inversion_invoice_ids = Invoice.search(cursor,uid,[
@@ -1691,10 +1691,10 @@ class GenerationkwhInvestment(osv.osv):
 
             # mark investment as canceled
             inv = InvestmentState(user['name'], datetime.now(),
-                log = inversio['log'],
-                purchase_date = inversio['purchase_date'],
-                draft = inversio['draft'],
-                active = inversio['active']
+                log = investment['log'],
+                purchase_date = investment['purchase_date'],
+                draft = investment['draft'],
+                active = investment['active']
             )
             inv.cancel()
 

--- a/som_generationkwh/tests/investment_tests.py
+++ b/som_generationkwh/tests/investment_tests.py
@@ -148,6 +148,10 @@ class InvestmentTests(testing.OOTestCase):
             inv_id = self.IrModelData.get_object_reference(
                         cursor, uid, 'som_generationkwh', 'apo_0001'
                         )[1]
+
+            member_id = self.IrModelData.get_object_reference(
+                cursor, uid, 'som_generationkwh', 'soci_0001')[1]
+
             inv_0001 = self.Investment.browse(cursor, uid, inv_id)
             self.assertEquals(inv_0001.signed_date, False)
 
@@ -168,7 +172,7 @@ class InvestmentTests(testing.OOTestCase):
                     'signed_date': '2017-01-06',
                     'draft': True,
                     'purchase_date': False,
-                    'member_id': (1, u'Gil, Pere'),
+                    'member_id': (member_id, u'Gil, Pere'),
                     'active': True,
                     'order_date': '2020-03-04',
                     'amortized_amount': 0.0,
@@ -197,6 +201,9 @@ class InvestmentTests(testing.OOTestCase):
                     'ES7712341234161234567890',
                     'APO_202006')
 
+            member_id = self.IrModelData.get_object_reference(
+                cursor, uid, 'som_generationkwh', 'soci_0001')[1]
+
             inv_0001 = self.Investment.read(cursor, uid, inv_id)
             inv_0001.pop('actions_log')
             inv_0001.pop('log')
@@ -212,7 +219,7 @@ class InvestmentTests(testing.OOTestCase):
                     'signed_date': False,
                     'draft': True,
                     'purchase_date': False,
-                    'member_id': (1, u'Gil, Pere'),
+                    'member_id': (member_id, u'Gil, Pere'),
                     'active': True,
                     'order_date': '2020-06-06',
                     'amortized_amount': 0.0,
@@ -242,6 +249,8 @@ class InvestmentTests(testing.OOTestCase):
                         '10.10.23.123',
                         'ES7712341234161234567890',
                         'APO_202006')
+                member_id = self.IrModelData.get_object_reference(
+                    cursor, uid, 'som_generationkwh', 'soci_0001')[1]
 
                 inv_0001 = self.Investment.read(cursor, uid, inv_id)
                 inv_0001.pop('actions_log')
@@ -258,7 +267,7 @@ class InvestmentTests(testing.OOTestCase):
                         'signed_date': False,
                         'draft': True,
                         'purchase_date': False,
-                        'member_id': (1, u'Gil, Pere'),
+                        'member_id': (member_id, u'Gil, Pere'),
                         'active': True,
                         'order_date': '2020-06-06',
                         'amortized_amount': 0.0,
@@ -1514,6 +1523,10 @@ class InvestmentTests(testing.OOTestCase):
             inv_id = self.IrModelData.get_object_reference(
                         cursor, uid, 'som_generationkwh', 'apo_0001'
                         )[1]
+
+            member_id = self.IrModelData.get_object_reference(
+                cursor, uid, 'som_generationkwh', 'soci_0001')[1]
+
             inv_0001 = self.Investment.browse(cursor, uid, inv_id)
             self.Investment.mark_as_invoiced(cursor, uid, inv_id)
 
@@ -1538,7 +1551,7 @@ class InvestmentTests(testing.OOTestCase):
                     'signed_date': False,
                     'draft': False,
                     'purchase_date': '2017-01-06',
-                    'member_id': (1, u'Gil, Pere'),
+                    'member_id': (member_id, u'Gil, Pere'),
                     'active': True,
                     'order_date': '2020-03-04',
                     'amortized_amount': 0.0,
@@ -1556,6 +1569,10 @@ class InvestmentTests(testing.OOTestCase):
             inv_id = self.IrModelData.get_object_reference(
                         cursor, uid, 'som_generationkwh', 'genkwh_0001'
                         )[1]
+
+            member_id = self.IrModelData.get_object_reference(
+                cursor, uid, 'som_generationkwh', 'soci_0001')[1]
+
             inv_0001 = self.Investment.browse(cursor, uid, inv_id)
             self.Investment.mark_as_invoiced(cursor, uid, inv_id)
 
@@ -1580,7 +1597,7 @@ class InvestmentTests(testing.OOTestCase):
                     'signed_date': False,
                     'draft': False,
                     'purchase_date': '2017-01-06',
-                    'member_id': (1, u'Gil, Pere'),
+                    'member_id': (member_id, u'Gil, Pere'),
                     'active': True,
                     'order_date': '2019-10-01',
                     'amortized_amount': 0.0,
@@ -1595,13 +1612,20 @@ class InvestmentTests(testing.OOTestCase):
         with Transaction().start(self.database) as txn:
             cursor = txn.cursor
             uid = txn.user
-            inv_id = self.IrModelData.get_object_reference(
-                        cursor, uid, 'som_generationkwh', 'genkwh_0001'
-                        )[1]
+
+            member1_id = self.IrModelData.get_object_reference(
+                cursor, uid, 'som_generationkwh', 'soci_0001')[1]
+            
+            member2_id = self.IrModelData.get_object_reference(
+                cursor, uid, 'som_generationkwh', 'soci_generation')[1]
 
             inv_tuple = self.Investment.effective_investments_tuple(cursor, uid)
 
-            self.assertEquals(inv_tuple, [(1, False, False, 10), (1, '2020-10-12', '2044-10-12', 10), (5, '2020-11-12', '2044-11-12', 5)])
+            self.assertEquals(inv_tuple, [
+                (member1_id, False, False, 10),
+                (member1_id, '2020-10-12', '2044-10-12', 10),
+                (member2_id, '2020-11-12', '2044-11-12', 5),
+            ])
 
     def test__effective_investments_tuple__allAPO(self):
         """
@@ -1611,15 +1635,22 @@ class InvestmentTests(testing.OOTestCase):
         with Transaction().start(self.database) as txn:
             cursor = txn.cursor
             uid = txn.user
-            inv_id = self.IrModelData.get_object_reference(
-                        cursor, uid, 'som_generationkwh', 'genkwh_0001'
-                        )[1]
+
+            member1_id = self.IrModelData.get_object_reference(
+                cursor, uid, 'som_generationkwh', 'soci_0001')[1]
+
+            member2_id = self.IrModelData.get_object_reference(
+                cursor, uid, 'som_generationkwh', 'soci_aportacions')[1]
 
             inv_tuple = self.Investment.effective_investments_tuple(cursor, uid, emission_type='apo')
 
-            self.assertEquals(set(inv_tuple), set([(1, False, False, 50), (1, False, False, 10), (4, '2020-03-12', False, 10)]))
+            self.assertEquals(set(inv_tuple), set([
+                (member1_id, False, False, 50),
+                (member1_id, False, False, 10),
+                (member2_id, '2020-03-12', False, 10),
+            ]))
 
-    def test__effective_investments_tuple__oneAPO(self):
+    def test__effective_investments_tuple__filteredByEmissionCode(self):
         """
         Check effective investments tuple, only Generation
         :return:
@@ -1631,9 +1662,12 @@ class InvestmentTests(testing.OOTestCase):
                         cursor, uid, 'som_generationkwh', 'genkwh_0001'
                         )[1]
 
+            member_id = self.IrModelData.get_object_reference(
+                cursor, uid, 'som_generationkwh', 'soci_0001')[1]
+
             inv_tuple = self.Investment.effective_investments_tuple(cursor, uid, emission_type='apo', emission_code='APO_202006')
 
-            self.assertEquals(inv_tuple, [(1, False, False, 50)])
+            self.assertEquals(inv_tuple, [(member_id, False, False, 50)])
 
     def test__member_has_effective__onlyGKWH(self):
         """

--- a/som_generationkwh/tests/investment_tests.py
+++ b/som_generationkwh/tests/investment_tests.py
@@ -1732,7 +1732,7 @@ class InvestmentTests(testing.OOTestCase):
             has_effectives = self.Investment.member_has_effective(cursor, uid, member_id, '2010-01-01','2022-01-01', emission_type='apo')
 
             self.assertFalse(has_effectives)
-            
+
     def test__pending_amortization_summary__manyAmortizationsSameInvestment(self):
         with Transaction().start(self.database) as txn:
             cursor = txn.cursor
@@ -1751,7 +1751,7 @@ class InvestmentTests(testing.OOTestCase):
 
             self.assertEqual((4, 120),
                 self.Investment.pending_amortization_summary(cursor, uid, '2022-11-20'))
-            
+
     def test__send_emails_to_investors_with_savings_in_year__whenNoGenkwhEmission(self):
         """
         Check send_emails_to_investors_with_savings_in_year when no emissions for Generationkwh
@@ -1858,7 +1858,7 @@ class InvestmentTests(testing.OOTestCase):
             ret_value = self.Soci.send_emails_to_investors_with_savings_in_year(cursor, uid, year=2020)
             self.assertEqual(ret_value, len(investments))
 
-           
+
     def test__get_stats_investment_generation__when_last_effective_date(self):
         """
         Check get_stats_investment_generation when some investements with last_effective_date
@@ -2021,7 +2021,7 @@ class InvestmentTests(testing.OOTestCase):
                     investmentName: GKWH00001
                     investmentPurchaseDate: false
                     divestmentDate: '{invoice_date}'
-                    pendingCapital: 0.0 
+                    pendingCapital: 0.0
                   quantity: 1.0
                   product_id: '[GENKWH_AMOR] Amortització Generation kWh'
                   invoice_line_tax_id: []
@@ -2035,8 +2035,8 @@ class InvestmentTests(testing.OOTestCase):
                 - {p.id}
                 - {p.name}
                 payment_type:
-                - 3 
-                - Transferencia 
+                - 3
+                - Transferencia
                 sii_to_send: false
                 type: in_invoice
                 state: draft
@@ -2051,7 +2051,7 @@ class InvestmentTests(testing.OOTestCase):
                 investment_id=investment_id,
                 mandate_id=False,
                 ))
-                
+
     def test__create_divestment_invoice__withProfitOneYearOkGKWH(self):
         with Transaction().start(self.database) as txn:
             cursor = txn.cursor
@@ -2102,7 +2102,7 @@ class InvestmentTests(testing.OOTestCase):
                     investmentName: GKWH00001
                     investmentPurchaseDate: false
                     divestmentDate: '{invoice_date}'
-                    pendingCapital: 0.0 
+                    pendingCapital: 0.0
                   quantity: 1.0
                   product_id: '[GENKWH_AMOR] Amortització Generation kWh'
                   invoice_line_tax_id: []
@@ -2138,8 +2138,8 @@ class InvestmentTests(testing.OOTestCase):
                 - {p.id}
                 - {p.name}
                 payment_type:
-                - 3 
-                - Transferencia 
+                - 3
+                - Transferencia
                 sii_to_send: false
                 type: in_invoice
                 state: draft
@@ -2207,7 +2207,7 @@ class InvestmentTests(testing.OOTestCase):
                     investmentName: GKWH00001
                     investmentPurchaseDate: false
                     divestmentDate: '{invoice_date}'
-                    pendingCapital: 0.0 
+                    pendingCapital: 0.0
                   quantity: 1.0
                   product_id: '[GENKWH_AMOR] Amortització Generation kWh'
                   invoice_line_tax_id: []
@@ -2265,8 +2265,8 @@ class InvestmentTests(testing.OOTestCase):
                 - {p.id}
                 - {p.name}
                 payment_type:
-                - 3 
-                - Transferencia 
+                - 3
+                - Transferencia
                 sii_to_send: false
                 type: in_invoice
                 state: draft
@@ -2335,7 +2335,7 @@ class InvestmentTests(testing.OOTestCase):
                     investmentName: GKWH00001
                     investmentPurchaseDate: false
                     divestmentDate: '{invoice_date}'
-                    pendingCapital: 0.0 
+                    pendingCapital: 0.0
                   quantity: 1.0
                   product_id: '[GENKWH_AMOR] Amortització Generation kWh'
                   invoice_line_tax_id: []
@@ -2393,8 +2393,8 @@ class InvestmentTests(testing.OOTestCase):
                 - {p.id}
                 - {p.name}
                 payment_type:
-                - 3 
-                - Transferencia 
+                - 3
+                - Transferencia
                 sii_to_send: false
                 type: in_invoice
                 state: draft
@@ -2461,7 +2461,7 @@ class InvestmentTests(testing.OOTestCase):
                     investmentName: APO00001
                     investmentPurchaseDate: false
                     divestmentDate: '{invoice_date}'
-                    pendingCapital: 0.0 
+                    pendingCapital: 0.0
                   quantity: 1.0
                   product_id: '[APO_AE] Aportacions'
                   invoice_line_tax_id: []
@@ -2475,8 +2475,8 @@ class InvestmentTests(testing.OOTestCase):
                 - {p.id}
                 - {p.name}
                 payment_type:
-                - 3 
-                - Transferencia 
+                - 3
+                - Transferencia
                 sii_to_send: false
                 type: in_invoice
                 state: draft
@@ -2502,7 +2502,7 @@ class InvestmentTests(testing.OOTestCase):
             member_id = self.IrModelData.get_object_reference(
                 cursor, uid, 'som_generationkwh', 'soci_0001'
             )[1]
-            
+
             self.Investment.write(cursor, uid, investment_id, {'member_id': member_id})
             
             self.Investment.divest(cursor, uid, [investment_id])

--- a/som_generationkwh/tests/partner_tests.py
+++ b/som_generationkwh/tests/partner_tests.py
@@ -2,13 +2,18 @@
 from destral import testing
 from destral.transaction import Transaction
 from destral.patch import PatchNewCursors
+from yamlns import namespace as ns
 import netsvc
 import time
 import random
 
 
 class PartnerTests(testing.OOTestCase):
+
+    from yamlns.testutils import assertNsEqual
+
     def setUp(self):
+        self.maxDiff = None
         self.pool = self.openerp.pool
         self.imd_obj = self.pool.get('ir.model.data')
         self.emission_obj = self.pool.get('generationkwh.emission')
@@ -104,21 +109,38 @@ class PartnerTests(testing.OOTestCase):
             partner_id = self.IrModelData.get_object_reference(
                         cursor, uid, 'som_generationkwh', 'res_partner_inversor1'
                         )[1]
+            member_id = self.IrModelData.get_object_reference(
+                cursor, uid, 'som_generationkwh', 'soci_0001')[1]
 
             inv_list = self.partner_obj.www_generationkwh_investments(cursor, uid, partner_id)
 
             for inv in inv_list:
                 inv.pop('id')
-            self.assertEquals(inv_list, [
-                {'nominal_amount': 1000.0, 'first_effective_date': False, 
-                    'name': u'GKWH00001', 'last_effective_date': False, 'draft': True,
-                    'purchase_date': False, 'member_id': (1, u'Gil, Pere'), 'active': True,
-                    'order_date': '2019-10-01', 'amortized_amount': 0.0, 'nshares': 10},
-                {'nominal_amount': 1000.0, 'first_effective_date': '2020-10-12', 
-                    'name': u'GKWH00002', 'last_effective_date': '2044-10-12', 'draft': True,
-                    'purchase_date': '2019-10-12', 'member_id': (1, u'Gil, Pere'), 'active': True,
-                    'order_date': '2019-10-01', 'amortized_amount': 0.0, 'nshares': 10}
-            ])
+            self.assertNsEqual(ns(entries=inv_list), """
+                entries:
+                - nominal_amount: 1000.0
+                  name: GKWH00001
+                  order_date: '2019-10-01'
+                  purchase_date: false
+                  first_effective_date: false
+                  last_effective_date: false
+                  draft: true
+                  member_id: [{member_id}, 'Gil, Pere']
+                  active: true
+                  amortized_amount: 0.0
+                  nshares: 10
+                - nominal_amount: 1000.0
+                  name: GKWH00002
+                  order_date: '2019-10-01'
+                  purchase_date: '2019-10-12'
+                  first_effective_date: '2020-10-12'
+                  last_effective_date: '2044-10-12'
+                  draft: true
+                  member_id: [{member_id}, 'Gil, Pere']
+                  active: true
+                  amortized_amount: 0.0
+                  nshares: 10
+            """.format(member_id=member_id))
 
     def test__www_aportacions_investments__twoAPO(self):
         with Transaction().start(self.database) as txn:
@@ -127,21 +149,38 @@ class PartnerTests(testing.OOTestCase):
             partner_id = self.IrModelData.get_object_reference(
                         cursor, uid, 'som_generationkwh', 'res_partner_inversor1'
                         )[1]
+            member_id = self.IrModelData.get_object_reference(
+                cursor, uid, 'som_generationkwh', 'soci_0001')[1]
 
             inv_list = self.partner_obj.www_aportacions_investments(cursor, uid, partner_id)
 
             for inv in inv_list:
                 inv.pop('id')
-            self.assertEquals(inv_list, [
-                {'nominal_amount': 1000.0, 'first_effective_date': False, 'name': u'APO00001',
-                    'last_effective_date': False, 'draft': True, 'purchase_date': False,
-                    'member_id': (1, u'Gil, Pere'), 'active': True, 'order_date': '2020-03-04',
-                    'amortized_amount': 0.0, 'nshares': 10},
-                {'nominal_amount': 5000.0, 'first_effective_date': False, 'name': u'APO00002',
-                    'last_effective_date': False, 'draft': True, 'purchase_date': False,
-                    'member_id': (1, u'Gil, Pere'), 'active': True, 'order_date': '2020-06-01',
-                    'amortized_amount': 0.0, 'nshares': 50}
-            ])
+            self.assertNsEqual(ns(entries=inv_list), """
+                entries:
+                - nominal_amount: 1000.0
+                  name: APO00001
+                  order_date: '2020-03-04'
+                  purchase_date: false
+                  first_effective_date: false
+                  last_effective_date: false
+                  draft: true
+                  member_id: [{member_id}, 'Gil, Pere']
+                  active: true
+                  amortized_amount: 0.0
+                  nshares: 10
+                - nominal_amount: 5000.0
+                  name: APO00002
+                  order_date: '2020-06-01'
+                  purchase_date: false
+                  first_effective_date: false
+                  last_effective_date: false
+                  draft: true
+                  member_id: [{member_id}, 'Gil, Pere']
+                  active: true
+                  amortized_amount: 0.0
+                  nshares: 50
+            """.format(member_id=member_id))
 
     def test__www_generationkwh_assignments__twoGKWH(self):
         with Transaction().start(self.database) as txn:
@@ -163,7 +202,7 @@ class PartnerTests(testing.OOTestCase):
             self.assertEquals(assig_list, [{'annual_use_kwh': False,
                 'contract_address': u'carrer inventat 1 1 1 1 aclaridor 00001 (Poble de Prova)',
                 'contract_id': 1, 'contract_last_invoiced': False, 'contract_name': u'0001C',
-                'contract_state': u'esborrany', 'member_id': 1, 'member_name': u'Gil, Pere',
+                'contract_state': u'esborrany', 'member_id': member_id, 'member_name': u'Gil, Pere',
                 'priority': 0}])
 
 # vim: et ts=4 sw=4


### PR DESCRIPTION
Actions logs should be additive but InvestmentState was not initialized with previous action log, resulting in every action clearing previous actions log.

This PR solves this. Also renames some spanish/catalan variable names.