### PR TITLE
Afegida variable de configuració per interès en les aportacions

### DIFF
--- a/som_generationkwh/emission.py
+++ b/som_generationkwh/emission.py
@@ -145,6 +145,13 @@ class GenerationkwhEmission(osv.osv):
         self.write(cr,uid,ids,{'state': 'cancel',})
         return True
 
+    def current_interest(self, cr, uid):
+        cfg_obj = self.pool.get('res.config')
+        current_interest = float(
+            cfg_obj.get(cr, uid, 'som_aportacions_interest', '0')
+        )
+        return current_interest
+
 GenerationkwhEmission()
 
 # vim: et ts=4 sw=4

--- a/som_generationkwh/som_generationkwh_data.xml
+++ b/som_generationkwh/som_generationkwh_data.xml
@@ -1742,5 +1742,14 @@ ${text_legal}
             <field name="investment_product_id" ref="apo_product_ae" />
             <field name="investment_payment_mode_id" ref="apo_investment_payment_mode"/>
         </record>
+
+        <record model="res.config" id="som_aportacions_interest">
+            <field name="name">som_aportacions_interest</field>
+            <field name="value"></field>
+            <field name="description">
+                Definim l'interes aplicat actualment en les aportacions fetes al capital social.
+                Decimal definit amb punt. Exemple: "1.5"
+            </field>
+        </record>
     </data>
 </openerp>


### PR DESCRIPTION
## Objetivos

- Consultar l'interès actual aplicat a les aportacions

## Comportamiento antiguo

- Inexistent

## Comportamiento nuevo

- Variable de configuració `som_aportacions_interest`
- Funció `current_interest` del model `generationkwh.emission`

## Afectaciones / Migración de datos

- [X] Código. Reiniciar servicios
- [X] Actualización módulos:
    - `som_generationkwh`
- [ ] Migración de datos
    - especificar que módulos y versión

## Variables de configuración

- `som_aportacions_interest`: float.

## Checklist

- [ ] Test code
- [ ] Documentation (link to [PowERP docs](https://github.com/gisce/powerp-docs) repo)
- [ ] Si se modifica alguna vista poner una captura indicando qué se modifica
- [ ] Si se modifica un report adjuntar el report
- [ ] Migration data
