### PR TITLE
Correcció estalvi generation AEAT 193

### DIFF
--- a/som_generationkwh/sql/aeat193_from_gkwh_invoices_query.sql
+++ b/som_generationkwh/sql/aeat193_from_gkwh_invoices_query.sql
@@ -1,7 +1,14 @@
-SELECT gkwh_owner.owner_id AS partner_id, par.vat as vat, SUM(gkwh_owner.saving_gkw_amount) as amount
-FROM generationkwh_invoice_line_owner gkwh_owner
-INNER JOIN giscedata_facturacio_factura f ON f.id=gkwh_owner.factura_id
-INNER JOIN account_invoice i ON i.id=f.invoice_id
-INNER JOIN res_partner par ON par.id = gkwh_owner.owner_id
-WHERE i.date_invoice BETWEEN %(start)s AND %(end)s
-GROUP BY gkwh_owner.owner_id, par.vat
+SELECT owner_id AS partner_id, owner_vat AS vat, SUM(savings) AS amount
+FROM (SELECT gkwh_owner.factura_line_id AS factura_line_id,
+             max(gkwh_owner.saving_gkw_amount) AS savings,
+             max(gkwh_owner.id) AS gkwh_id,
+             max(gkwh_owner.owner_id) AS owner_id,
+             max(par.vat) AS owner_vat
+      FROM generationkwh_invoice_line_owner gkwh_owner
+      INNER JOIN giscedata_facturacio_factura f ON f.id=gkwh_owner.factura_id
+      INNER JOIN account_invoice i ON i.id=f.invoice_id
+      INNER JOIN res_partner par ON par.id = gkwh_owner.owner_id
+      WHERE i.date_invoice BETWEEN %(start)s AND %(end)s
+      GROUP BY gkwh_owner.factura_line_id ORDER BY gkwh_owner.factura_line_id  DESC) AS parcial
+GROUP BY owner_id, owner_id, owner_vat
+ORDER BY owner_id;


### PR DESCRIPTION
## Objetivos

- Corregir error detectat en l'estalvi en generation durant un canvi de tarifes pel model 193 de l'AEAT.

## Comportamiento antiguo

- Sumatori de totes les linies, fins i tot amb ids de linies de factures repetides.

## Comportamiento nuevo

- Consultar l'estalvi sumant les linies de `generationkwh.invoice.line.owner` per partner en un periode, agafant l'esltavi major en cas de trobar dues linies d'estalvi per a una maitexa linia de factura.

## Afectaciones / Migración de datos

- [X] Código. Reiniciar servicios
- [ ] Actualización módulos:
    - `som_generationkwh`
- [ ] Migración de datos
    - especificar que módulos y versión

## Checklist

- [ ] Test code
- [ ] Documentation (link to [PowERP docs](https://github.com/gisce/powerp-docs) repo)
- [ ] Si se modifica alguna vista poner una captura indicando qué se modifica
- [ ] Si se modifica un report adjuntar el report
- [ ] Migration data
