### PR TITLE
Markdown readme requires defining content_type

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,8 +12,10 @@ setup(
     author_email = "info@somenergia.coop",
     url = 'https://github.com/Som-Energia/somenergia-generationkwh',
     long_description = readme,
+    long_description_content_type = 'text/markdown',
     license = 'GNU Affero General Public License v3 or later (AGPLv3+)',
     packages=find_packages(exclude=['*[tT]est*']),
+
     scripts=[
         'scripts/genkwh_assignments.py',
         'scripts/genkwh_investments.py',
@@ -27,6 +29,7 @@ setup(
         'scripts/genkwh_remainders.py',
         ],
     install_requires=[
+        'setuptools>=20.4', # markdown readme
         'yamlns>=0.6',
         'b2btest',
         'lxml', # b2btest dependency, to remove


### PR DESCRIPTION
PyPi problems reported in #41 are because the default description format in pypi is REST not Markdown. Since setuptools 20.4 you can specify the mimetype as markdown. This should do the work.

This is required in order to be able to upload the library to a pypi repository.