### PR TITLE
Set poweremail core account by id

### DIFF
--- a/som_generationkwh/migrations/2.5.6/pre-0001_new_semantic_ids.py
+++ b/som_generationkwh/migrations/2.5.6/pre-0001_new_semantic_ids.py
@@ -10,7 +10,7 @@ def up(cursor, installed_version):
     xml_content = '''<?xml version="1.0" encoding="UTF-8" ?>
     <openerp>
         <data>
-            <record model="poweremail.core_accounts" id="genertion_mail_account">
+            <record model="poweremail.core_accounts" id="generation_mail_account">
                 <field name="email_id">generationkwh@somenergia.coop</field>
                 <field name="company">yes</field>
                 <field name="smtpserver">smtp.mandrillapp.com</field>

--- a/som_generationkwh/report/report_retencions_gkwh.py
+++ b/som_generationkwh/report/report_retencions_gkwh.py
@@ -126,22 +126,15 @@ class RetencionsSobreRendimentGenerationKwh():
         Return email from poweremail template
         """
         ir_model_data = _object.pool.get('ir.model.data')
-        account_obj = _object.pool.get('poweremail.core_accounts')
         power_email_tmpl_obj = _object.pool.get('poweremail.templates')
 
         template_id = ir_model_data.get_object_reference(
             cursor, uid, 'som_generationkwh', 'certificat_retencio_rendiment_generationkwh'
         )[1]
-        template = power_email_tmpl_obj.read(cursor, uid, template_id)
 
-        email_from = False
-        template_name = 'Generation'
-
-        if template.get(template_name):
-            email_from = template.get('enforce_from_account')[0]
-
-        if not email_from:
-            email_from = account_obj.search(cursor, uid, [('name', 'ilike', template_name)])[0]
+        email_from = ir_model_data.get_object_reference(
+            cursor, uid, 'som_generationkwh', 'genertion_mail_account'
+        )[1]
 
         email_params = dict({
             'email_from': email_from,

--- a/som_generationkwh/report/report_retencions_gkwh.py
+++ b/som_generationkwh/report/report_retencions_gkwh.py
@@ -133,7 +133,7 @@ class RetencionsSobreRendimentGenerationKwh():
         )[1]
 
         email_from = ir_model_data.get_object_reference(
-            cursor, uid, 'som_generationkwh', 'genertion_mail_account'
+            cursor, uid, 'som_generationkwh', 'generation_mail_account'
         )[1]
 
         email_params = dict({

--- a/som_generationkwh/som_generationkwh_data.xml
+++ b/som_generationkwh/som_generationkwh_data.xml
@@ -10,7 +10,7 @@
         <record model="product.category" id="categ_inversions">
             <field name="name">Inversions</field>
         </record>
-        <record model="poweremail.core_accounts" id="genertion_mail_account">
+        <record model="poweremail.core_accounts" id="generation_mail_account">
             <field name="email_id">generationkwh@somenergia.coop</field>
             <field name="company">yes</field>
             <field name="smtpserver">smtp.mandrillapp.com</field>
@@ -1485,7 +1485,7 @@ ${text_legal}
             <field name="lang">${object.partner_id.lang}</field>
             <field name="copyvalue">${object.partner_id.lang}</field>
             <field eval="0" name="send_on_write"/>
-            <field name="enforce_from_account" ref="genertion_mail_account"/>
+            <field name="enforce_from_account" ref="generation_mail_account"/>
             <field name="def_body_text"><![CDATA[
 <!doctype html>
 <html><body>

--- a/som_generationkwh/tests/generation_data_demo.xml
+++ b/som_generationkwh/tests/generation_data_demo.xml
@@ -272,7 +272,7 @@
             <field name="name">Partner</field>
             <field name="object">res.partner</field>
         </record>
-        <record model="poweremail.core_accounts" id="genertion_mail_account">
+        <record model="poweremail.core_accounts" id="generation_mail_account">
             <field name="email_id">generationkwh@somenergia.coop</field>
             <field name="company">yes</field>
             <field name="smtpserver">smtp.mandrillapp.com</field>


### PR DESCRIPTION
## Objetivos

- Corregir error detectat en assignar el compte origen d'enviament massiu de certificats de retenció gkwh

## Comportamiento antiguo

- Estavem assignant un compte desactivat de generationkwh

## Comportamiento nuevo

- Per evitar errors, fem la cerca per l'id semàntic

## Afectaciones / Migración de datos

- [X] Código. Reiniciar servicios
- [ ] Actualización módulos:
    - `som_generationkwh`
- [ ] Migración de datos
    - especificar que módulos y versión
