### PR TITLE
ADD origin_date_invoice to amortization invoices

### DIFF
--- a/som_generationkwh/investment.py
+++ b/som_generationkwh/investment.py
@@ -855,6 +855,7 @@ class GenerationkwhInvestment(osv.osv):
             #'check_total': to_be_amortized + (irpf_amount * -1),
             # TODO: Remove the GENKWHID stuff when fully migrated, error instead
             'origin': investment.name or 'GENKWHID{}'.format(investment.id),
+            'origin_date_invoice': date_invoice,
             'reference': invoice_name,
             'date_invoice': date_invoice,
         })

--- a/som_generationkwh/tests/wizard_llibre_tests.py
+++ b/som_generationkwh/tests/wizard_llibre_tests.py
@@ -45,10 +45,10 @@ class TestsWizard(testing.OOTestCase):
         wiz_o = pool.get('wizard.llibre.registre.socis')
         soci_id = self.get_object_id('som_generationkwh', 'soci_aportacions')
         soci_o.write(cursor, uid, soci_id, {'date': '2017-01-01'})
+        context = {'date_from': '2017-01-01', 'date_to': '2017-12-31'}
+        values = wiz_o.get_aportacions_obligatories_values(cursor, uid, soci_id, context)
 
-        values = wiz_o.get_aportacions_obligatories_values(cursor, uid, soci_id)
-
-        self.assertEqual(values, [{'concepte': u'Aportaci\xf3n obligatoria',
+        self.assertEqual(values, [{'concepte': u'Obligatoria',
              'data': '2017-01-01',
              'import': 100}])
 
@@ -58,10 +58,10 @@ class TestsWizard(testing.OOTestCase):
         soci_o = pool.get('somenergia.soci')
         wiz_o = pool.get('wizard.llibre.registre.socis')
         soci_id = self.get_object_id('som_generationkwh', 'soci_aportacions')
+        context = {'date_from': '2020-01-01', 'date_to': '2020-12-31'}
+        values = wiz_o.get_aportacions_voluntaries_values(cursor, uid, soci_id, context)
 
-        values = wiz_o.get_aportacions_voluntaries_values(cursor, uid, soci_id)
-
-        self.assertEqual(values, [{'concepte': u'Aportaci\xf3n voluntaria',
+        self.assertEqual(values, [{'concepte': u'Voluntaria',
         'data': '2020-03-12',
         'import': 1000,
         'import_amortitzat': 0.0}])


### PR DESCRIPTION
- origin_date_invoice is now required field in view.
- create_amortization_invoice function is now setting an origin_date_invoice default value