### PR TITLE
Allow Debian oldstable

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,6 +92,7 @@ jobs:
           name: link addons
           command: |
             export ROOT_DIR_SRC=~/src
+            . venv/bin/activate
             cd $ROOT_DIR_SRC/erp && ./tools/link_addons.sh
         
       # run tests!

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,8 +49,6 @@ jobs:
             curl -H "Authorization: token $GITHUB_TOKEN" -L https://api.github.com/repos/gisce/pandapower_erp/tarball > /tmp/pandapower_erp.tar.gz
             curl -H "Authorization: token $GITHUB_TOKEN" -L https://api.github.com/repos/gisce/pandapower_validator/tarball > /tmp/pandapower_validator.tar.gz
             curl -H "Authorization: token $GITHUB_TOKEN" -L https://api.github.com/repos/gisce/ooop/tarball > /tmp/ooop.tar.gz
-            wget -O /tmp/egenix-mx-base-3.2.9.tar.gz http://downloads.egenix.com/python/egenix-mx-base-3.2.9.tar.gz
-            tar -xzvf /tmp/egenix-mx-base-3.2.9.tar.gz --directory /tmp
 
       # Download and cache dependencies
       - restore_cache:
@@ -74,9 +72,6 @@ jobs:
             pip install -r $ROOT_DIR_SRC/erp/requirements.txt
             test -x $ROOT_DIR_SRC/$TESTING_REPO/requirements.txt && pip install -r $ROOT_DIR_SRC/$TESTING_REPO/requirements.txt
             pip install face-lib
-            cd /tmp/egenix-mx-base-3.2.9
-            python setup.py install
-            cd -
 
       - run:
           name: Install somenenergia-generation depencencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,7 +60,7 @@ jobs:
       - run:
           name: Install dependencies
           command: |
-            sudo apt-get update
+            sudo apt-get update --allow-releaseinfo-change
             sudo apt-get install python-dev libxml2-dev libxmlsec1 libxmlsec1-dev -y
             export ROOT_DIR_SRC=~/src
             cd $ROOT_DIR_SRC


### PR DESCRIPTION
Fix 'oldstable' error in Debian CircleCI

```
Reading package lists... Done
N: Repository 'http://deb.debian.org/debian buster InRelease' changed its 'Version' value from '10.3' to '10.10'
E: Repository 'http://deb.debian.org/debian buster InRelease' changed its 'Suite' value from 'stable' to 'oldstable'
N: This must be accepted explicitly before updates for this repository can be applied. See apt-secure(8) manpage for details.
E: Repository 'http://security.debian.org/debian-security buster/updates InRelease' changed its 'Suite' value from 'stable' to 'oldstable'
N: This must be accepted explicitly before updates for this repository can be applied. See apt-secure(8) manpage for details.
E: Repository 'http://deb.debian.org/debian buster-updates InRelease' changed its 'Suite' value from 'stable-updates' to 'oldstable-updates'
N: This must be accepted explicitly before updates for this repository can be applied. See apt-secure(8) manpage for details.
```