### PR TITLE
Forçar la no agrupació de línies de GKWH quan el preu de tarifa canvia

### DIFF
--- a/som_generationkwh/giscedata_facturacio.py
+++ b/som_generationkwh/giscedata_facturacio.py
@@ -452,6 +452,7 @@ class GiscedataFacturacioFactura(osv.osv):
                         'quantity': gkwh_quantity,
                         'name': _(u'{0} GkWh').format(line_vals['name']),
                     })
+                    context['group_line'] = False
                     iline_id = invlines_obj.create(cursor, uid, vals, context)
                     # owner line object creation
                     gkwh_lineowner_obj.create(


### PR DESCRIPTION
Fins ara, quan hi havia canvi de tarifes (però de generation no canviava el preu) s'agrupaven les línies. Això, a més de no ser correcte, generava un problema alhora de calcular la retenció de IRPF, ja que el "estalvi" era diferent en funció del preu de tarifa.