### PR TITLE
Unit test workin in Py2 and Py3

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,10 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: install system dependencies
         run:
-          sudo apt install mongod
+          wget -qO - https://www.mongodb.org/static/pgp/server-3.2.asc | sudo apt-key add -
+          echo "deb http://repo.mongodb.org/apt/ubuntu trusty/mongodb-org/3.2 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-3.2.list
+          sudo apt-get update -y
+          sudo apt install mongodb-org-server
       - name: Install dependencies
         run: |
           pip install https://files.pythonhosted.org/packages/3e/5c/2867e46f03d2fcc3d014a02eeb11ec55f3f8d9eddddcc5578ae8457f84f8/ERPpeek-1.7.1-py2.py3-none-any.whl

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,10 +24,10 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: install system dependencies
-        run:
+        run: |
           wget -qO - https://www.mongodb.org/static/pgp/server-3.2.asc | sudo apt-key add -
           echo "deb http://repo.mongodb.org/apt/ubuntu trusty/mongodb-org/3.2 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-3.2.list
-          sudo apt-get update -y
+          sudo apt update
           sudo apt install mongodb-org-server
       - name: Install dependencies
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,6 +23,9 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
+      - name: install system dependencies
+        run:
+          sudo apt install mongod
       - name: Install dependencies
         run: |
           pip install https://files.pythonhosted.org/packages/3e/5c/2867e46f03d2fcc3d014a02eeb11ec55f3f8d9eddddcc5578ae8457f84f8/ERPpeek-1.7.1-py2.py3-none-any.whl

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,8 +14,10 @@ jobs:
       matrix:
         python-version:
           - '2.7' # production
-          - '3.5'
+          - '3.8'
           - '3.9'
+        mongodb-version:
+          - 2
     name: Python ${{ matrix.python-version }}
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
@@ -23,15 +25,15 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-      - name: install system dependencies
-        run: |
-          wget -qO - https://www.mongodb.org/static/pgp/server-3.2.asc | sudo apt-key add -
-          echo "deb http://repo.mongodb.org/apt/ubuntu trusty/mongodb-org/3.2 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-3.2.list
-          sudo apt update
-          sudo apt install mongodb-org-server
+      - name: Start MongoDB
+        uses: supercharge/mongodb-github-action@1.7.0
+        with:
+          mongodb-version: ${{ matrix.mongodb-version }}
+          mongodb-replica-set: test-rs
       - name: Install dependencies
         run: |
           pip install https://files.pythonhosted.org/packages/3e/5c/2867e46f03d2fcc3d014a02eeb11ec55f3f8d9eddddcc5578ae8457f84f8/ERPpeek-1.7.1-py2.py3-none-any.whl
+          pip install pytest-cov pytest
           ./setup.py develop
       - uses: BSFishy/pip-action@v1
         with:
@@ -40,7 +42,7 @@ jobs:
             git+https://github.com/som-energia/plantmeter.git@master
       - name: Unit tests
         run: |
-          coverage run --source generationkwh ./setup.py test
+          pytest
 
       - name: Coveralls
         uses: AndreMiras/coveralls-python-action@develop

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,0 +1,40 @@
+# This workflow will upload a Python Package using Twine when a release is created
+# For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: Upload Python Package
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+  push:
+    tags:
+      - 'generationkwh-[0-9]+.[0-9]+.[0-9]+'
+
+jobs:
+  deploy:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install build
+    - name: Build package
+      run: python -m build
+    - name: Publish package
+      uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_API_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 OpenERP module and library to manage [Som Energia]'s Generation kWh
 
-[![Build Status](https://travis-ci.org/Som-Energia/somenergia-generationkwh.svg?branch=master)](https://travis-ci.org/Som-Energia/somenergia-generationkwh)
+
+[![CI](https://github.com/Som-Energia/somenergia-generationkwh/actions/workflows/main.yml/badge.svg)](https://github.com/Som-Energia/somenergia-generationkwh/actions/workflows/main.yml)
 [![CircleCI](https://circleci.com/gh/Som-Energia/somenergia-generationkwh.svg?style=svg)](https://circleci.com/gh/Som-Energia/somenergia-generationkwh)
 [![Coverage Status](https://coveralls.io/repos/github/Som-Energia/somenergia-generationkwh/badge.svg)](https://coveralls.io/github/Som-Energia/somenergia-generationkwh)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,15 @@
+[coverage:run]
+relative_files = True
+branch = True
+omit =
+        **/*test.py
+source: generationkwh
+
+[tool:pytest]
+addopts: --doctest-modules --cov=generationkwh
+testpaths =
+    generationkwh
+
 [nosetests]
 
 verbosity=3

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,6 @@ setup(
         'tqdm',
         'b2btest',
         'lxml', # b2btest dependency, to remove
-        'wavefile', # b2btest dependency, to remove
         'numpy<1.17' if py2 else 'numpy', # Py2
         'decorator<5' if py2 else 'decorator', # Py2
         'plantmeter',
@@ -46,7 +45,7 @@ setup(
         'somutils',
         'mock<4' if py2 else '', # TODO: remove indirect dependency for Py2
         'pytest',
-        'pytest-cov',
+        'pytest-cov<3' if py2 else 'pytest-cov', # Py2
 #        'libfacturacioatr',
     ],
     include_package_data = True,

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,6 @@ setup(
         'decorator<5' if py2 else 'decorator', # Py2
         'plantmeter',
         'python-dateutil',
-        'python-dateutil',
         'consolemsg>=0.3',
         'somutils',
         'mock<4' if py2 else '', # TODO: remove indirect dependency for Py2

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
         'b2btest',
         'lxml', # b2btest dependency, to remove
         'wavefile', # b2btest dependency, to remove
-        'numpy<1.19' if py2 else 'numpy', # Py2
+        'numpy<1.17' if py2 else 'numpy', # Py2
         'decorator<5' if py2 else 'decorator', # Py2
         'plantmeter',
         'python-dateutil',

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
         'consolemsg>=0.3',
         'somutils',
         'tqdm',
-        'mock<4' if py2 else 'mock', # TODO: remove indirect dependency for Py2
+        'mock<4' if py2 else '', # TODO: remove indirect dependency for Py2
 #        'libfacturacioatr',
     ],
     include_package_data = True,

--- a/setup.py
+++ b/setup.py
@@ -37,14 +37,14 @@ setup(
         'b2btest',
         'lxml', # b2btest dependency, to remove
         'wavefile', # b2btest dependency, to remove
-        'numpy',
+        'numpy<1.19' if py2 else 'numpy', # Py2
+        'decorator<5' if py2 else 'decorator', # Py2
         'plantmeter',
         'python-dateutil',
         'python-dateutil',
         'consolemsg>=0.3',
         'somutils',
         'tqdm',
-        'decorator<5' if py2 else 'decorator', # Py2
         'mock<4' if py2 else 'mock', # TODO: remove indirect dependency for Py2
 #        'libfacturacioatr',
     ],

--- a/setup.py
+++ b/setup.py
@@ -45,11 +45,12 @@ setup(
         'consolemsg>=0.3',
         'somutils',
         'mock<4' if py2 else '', # TODO: remove indirect dependency for Py2
+        'pytest',
+        'pytest-cov',
 #        'libfacturacioatr',
     ],
     include_package_data = True,
     test_suite = 'generationkwh',
-#    test_runner = 'colour_runner.runner.ColourTextTestRunner',
     classifiers = [
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',

--- a/setup.py
+++ b/setup.py
@@ -41,10 +41,9 @@ setup(
         'decorator',
         'python-dateutil',
         'consolemsg>=0.3',
-        'somutils<1.7.1' if sys.version_info[0] < 3 else 'somutils', # gspread 4.0 not in Py2
+        'somutils',
         'tqdm',
         'mock<4', # TODO: remove indirect dependency for Py2
-        'rsa<4.6', # TODO: remove indirect dependency for Py2
 #        'libfacturacioatr',
     ],
     include_package_data = True,

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
         'consolemsg>=0.3',
         'somutils',
         'tqdm',
-        'mock<4', # TODO: remove indirect dependency for Py2
+        'mock<4' if sys.version_info < (3,) else 'mock', # TODO: remove indirect dependency for Py2
 #        'libfacturacioatr',
     ],
     include_package_data = True,

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ setup(
     install_requires=[
         'setuptools>=20.4', # markdown readme
         'yamlns>=0.6',
+        'tqdm',
         'b2btest',
         'lxml', # b2btest dependency, to remove
         'wavefile', # b2btest dependency, to remove
@@ -44,7 +45,6 @@ setup(
         'python-dateutil',
         'consolemsg>=0.3',
         'somutils',
-        'tqdm',
         'mock<4' if py2 else '', # TODO: remove indirect dependency for Py2
 #        'libfacturacioatr',
     ],

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,8 @@ from generationkwh import __version__
 import sys
 readme = open("README.md").read()
 
+py2 = sys.version_info<(3,)
+
 setup(
     name = "somenergia-generationkwh",
     version = __version__,
@@ -38,12 +40,12 @@ setup(
         'numpy',
         'plantmeter',
         'python-dateutil',
-        'decorator',
         'python-dateutil',
         'consolemsg>=0.3',
         'somutils',
         'tqdm',
-        'mock<4' if sys.version_info < (3,) else 'mock', # TODO: remove indirect dependency for Py2
+        'decorator<5' if py2 else 'decorator', # Py2
+        'mock<4' if py2 else 'mock', # TODO: remove indirect dependency for Py2
 #        'libfacturacioatr',
     ],
     include_package_data = True,


### PR DESCRIPTION
The following changes are done:

- Add github actions workflows for CI that install dependencies in Py2 and Py3 and pass the unittests. Functional tests (using erppeek) and Destral tests are not run yet.
- Add a gha workflow to publish the non-erp module as we push the version tag.
- Dependencies somutils and plantmonitor have been put under similar workflows (CI and pypi publish). 
- somutils and plantmonitor are already published. generationkwh is not, it should be published after this branch is merged.
- To get dependencies (somutils and plantmonitor) in green, conditional dependencies for Py2.7 had to be set as several libraries stopped suporting Py2. Althought it works standalone, interactions with dependencies of a full erp installation is to be checked.  Conditional restrictions are documented in setup.py of each project.
- Commonalities (isodate, run_destructive_test and so on...) were moved to somutils.
- Removed wavefile dependency (from b2btest, now modularized)
- success and coverage badges are included both in the README and in qa-control, besides the circle-ci badges