### PR TITLE
FIX dict initialization in `get_gkwh_shares_dict` 

### DIFF
--- a/som_generationkwh/giscedata_facturacio.py
+++ b/som_generationkwh/giscedata_facturacio.py
@@ -311,7 +311,7 @@ class GiscedataFacturacioFactura(osv.osv):
         periods = [(v[0], dict(zip(fields, v[1:]))) for v in vals]
 
         uniq_product_ids = set([p[0] for p in periods])
-        product_res = {}.fromkeys(uniq_product_ids, [])
+        product_res = {k: [] for k in uniq_product_ids}
 
         for p in periods:
             product_res[p[0]].append(p[1])


### PR DESCRIPTION
In Python, using:
{}.fromkeys(key_names, [])  sets the SAME object list for every element in the dictionary.

Meaning: 
```
a_dict = {}.fromkeys(['a','b'], []) 
a_dict['a'].append(0)
```
results in: 
```
a_dict = {'a':[0], 'b':[0]}
```

As a result, when an `out_refund` invoice is unlinked, the sum of all gkwh rights in the invoice was marked as used for each gkwh period in the invoice.