### PR TITLE
Exclude RMAG lines to apply gkwh (RD 10/2022)

### DIFF
--- a/som_generationkwh/giscedata_facturacio.py
+++ b/som_generationkwh/giscedata_facturacio.py
@@ -506,9 +506,9 @@ class GiscedataFacturacioFactura(osv.osv):
         if not rmag_lines_ids:
             return
 
-        rmag_line = self.browse(cursor, uid, rmag_lines_ids[0])
-
         line_obj = self.pool.get('giscedata.facturacio.factura.linia')
+        rmag_line = line_obj.browse(cursor, uid, rmag_lines_ids[0])
+
         cfg_obj = self.pool.get('res.config')
 
         start_date_mecanisme_ajust_gas = cfg_obj.get(

--- a/som_generationkwh/giscedata_facturacio.py
+++ b/som_generationkwh/giscedata_facturacio.py
@@ -343,10 +343,21 @@ class GiscedataFacturacioFactura(osv.osv):
         return factura_linia_ids
 
     def get_real_energy_lines(self, cursor, uid, inv_id, pol_id, linies_energia_ids):
+        product_obj = self.pool.get('product.product')
+        invline_obj = self.pool.get('giscedata.facturacio.factura.linia')
+        maj_product = product_obj.search(cursor, uid, [('default_code','=', 'RMAG')])
+        if maj_product:
+            maj_product = maj_product[0]
+        else:
+            maj_product = False
+
         real_energy = []
         lines_extra_ids = self.get_lines_in_extralines(cursor, uid, inv_id, pol_id)
         for l_id in linies_energia_ids:
             if l_id not in lines_extra_ids:
+                line = invline_obj.browse(cursor, uid, l_id)
+                if line.product_id.id == maj_product:
+                    continue
                 real_energy.append(l_id)
         return real_energy
 

--- a/som_generationkwh/som_generationkwh.py
+++ b/som_generationkwh/som_generationkwh.py
@@ -529,14 +529,27 @@ class GenerationkWhInvoiceLineOwner(osv.osv):
 
     def getProfit(self, cr, uid, line):
         ai_obj = self.pool.get('account.invoice')
+        cfg_obj = self.pool.get('res.config')
 
         if line['quantity'] == 0:
             return 0
 
+        start_date_mecanisme_ajust_gas = cfg_obj.get(
+            cr, uid, 'start_date_mecanisme_ajust_gas', '2022-10-01')
+        end_date_mecanisme_ajust_gas = cfg_obj.get(
+            cr, uid, 'end_date_mecanisme_ajust_gas', '2099-12-31')
+
         priceNoGen = float(self.getPriceWithoutGeneration(cr, uid, line)['price_unit'])
+        rmag_lines = self.browse(cr, uid, line).factura_id.get_rmag_lines()
+        if rmag_lines and \
+                line['data_desde'] >= start_date_mecanisme_ajust_gas and \
+                line['data_fins'] <= end_date_mecanisme_ajust_gas:
+            profit = (priceNoGen + rmag_lines[0]['price_unit'] - line['price_unit']) * line['quantity']
+        else:
+            profit = (priceNoGen - line['price_unit']) * line['quantity']
         if ai_obj.read(cr, uid, line['invoice_id'][0], ['type'])['type'] == 'out_refund':
-            return round((priceNoGen - line['price_unit']) * line['quantity'] * -1,2)
-        return round((priceNoGen - line['price_unit']) * line['quantity'],2)
+            return round(profit * -1, 2)
+        return round(profit ,2)
 
 
     def _ff_saving_generation(self, cursor, uid, ids, field_name, arg,

--- a/som_generationkwh/som_generationkwh.py
+++ b/som_generationkwh/som_generationkwh.py
@@ -540,13 +540,16 @@ class GenerationkWhInvoiceLineOwner(osv.osv):
             cr, uid, 'end_date_mecanisme_ajust_gas', '2099-12-31')
 
         priceNoGen = float(self.getPriceWithoutGeneration(cr, uid, line)['price_unit'])
-        rmag_lines = self.browse(cr, uid, line).factura_id.get_rmag_lines()
-        if rmag_lines and \
+        rmag_lines_ids = self.browse(cr, uid, line).factura_id.get_rmag_lines()
+
+        if rmag_lines_ids and \
                 line['data_desde'] >= start_date_mecanisme_ajust_gas and \
                 line['data_fins'] <= end_date_mecanisme_ajust_gas:
-            profit = (priceNoGen + rmag_lines[0]['price_unit'] - line['price_unit']) * line['quantity']
+            rmag_line = self.browse(cr, uid, rmag_lines_ids[0])
+            profit = (priceNoGen + rmag_line.price_unit - line['price_unit']) * line['quantity']
         else:
             profit = (priceNoGen - line['price_unit']) * line['quantity']
+
         if ai_obj.read(cr, uid, line['invoice_id'][0], ['type'])['type'] == 'out_refund':
             return round(profit * -1, 2)
         return round(profit ,2)

--- a/som_generationkwh/som_generationkwh.py
+++ b/som_generationkwh/som_generationkwh.py
@@ -545,7 +545,7 @@ class GenerationkWhInvoiceLineOwner(osv.osv):
         if rmag_lines and \
                 line['data_desde'] >= start_date_mecanisme_ajust_gas and \
                 line['data_fins'] <= end_date_mecanisme_ajust_gas:
-            rmag_line = self.browse(cr, uid, rmag_lines_ids[0])
+            rmag_line = gffl_obj.browse(cr, uid, rmag_lines[0])
             profit = (priceNoGen + rmag_line.price_unit - line['price_unit']) * line['quantity']
         else:
             profit = (priceNoGen - line['price_unit']) * line['quantity']

--- a/som_generationkwh/som_generationkwh.py
+++ b/som_generationkwh/som_generationkwh.py
@@ -530,6 +530,7 @@ class GenerationkWhInvoiceLineOwner(osv.osv):
     def getProfit(self, cr, uid, line):
         ai_obj = self.pool.get('account.invoice')
         cfg_obj = self.pool.get('res.config')
+        gffl_obj = self.pool.get('giscedata.facturacio.factura.linia')
 
         if line['quantity'] == 0:
             return 0
@@ -540,9 +541,8 @@ class GenerationkWhInvoiceLineOwner(osv.osv):
             cr, uid, 'end_date_mecanisme_ajust_gas', '2099-12-31')
 
         priceNoGen = float(self.getPriceWithoutGeneration(cr, uid, line)['price_unit'])
-        rmag_lines_ids = self.browse(cr, uid, line).factura_id.get_rmag_lines()
-
-        if rmag_lines_ids and \
+        rmag_lines = gffl_obj.browse(cr, uid, line['id']).factura_id.get_rmag_lines()
+        if rmag_lines and \
                 line['data_desde'] >= start_date_mecanisme_ajust_gas and \
                 line['data_fins'] <= end_date_mecanisme_ajust_gas:
             rmag_line = self.browse(cr, uid, rmag_lines_ids[0])
@@ -564,6 +564,7 @@ class GenerationkWhInvoiceLineOwner(osv.osv):
         gffl_obj = self.pool.get('giscedata.facturacio.factura.linia')
 
         res = {k: {} for k in ids}
+
         for gilo_line in self.browse(cursor, uid, ids):
             line = gffl_obj.read(cursor, uid, gilo_line.factura_line_id.id)
             res[gilo_line.id] = self.getProfit(cursor, uid, line)


### PR DESCRIPTION
Energy lines corresponding to RMAG product (RD 10/2022) are excluded in apply_gkwh

Gkwh price does not increase by MAG, so total MAG line quantity has to be adjusted. In consequence, gkwh savings need to be computed taking MAG into account
