### PR TITLE
Inherit from osv_memory instead of osv

### DIFF
--- a/som_generationkwh/wizard/wizard_baixa_soci.py
+++ b/som_generationkwh/wizard/wizard_baixa_soci.py
@@ -4,7 +4,7 @@ from osv import osv, fields
 from tools.translate import _
 import logging
 
-class WizardBaixaSoci(osv.osv):
+class WizardBaixaSoci(osv.osv_memory):
 
     _name = 'wizard.baixa.soci'
     _columns = {

--- a/som_generationkwh/wizard/wizard_investment_activation.py
+++ b/som_generationkwh/wizard/wizard_investment_activation.py
@@ -6,7 +6,7 @@ from osv import osv, fields
 from tools.translate import _
 
 
-class WizardInvestmentActivation(osv.osv):
+class WizardInvestmentActivation(osv.osv_memory):
 
     _name = 'wizard.generationkwh.investment.activation'
 

--- a/som_generationkwh/wizard/wizard_investment_cancel_or_resign.py
+++ b/som_generationkwh/wizard/wizard_investment_cancel_or_resign.py
@@ -5,7 +5,7 @@ from osv import osv, fields
 from tools.translate import _
 import pickle
 
-class WizardInvestmentCancelOrResing(osv.osv):
+class WizardInvestmentCancelOrResing(osv.osv_memory):
 
     _name = 'wizard.generationkwh.investment.cancel.or.resign'
     _columns = {

--- a/som_generationkwh/wizard/wizard_investment_creation.py
+++ b/som_generationkwh/wizard/wizard_investment_creation.py
@@ -6,7 +6,7 @@ from osv import osv, fields
 from tools.translate import _
 
 
-class WizardInvestmentCreation(osv.osv):
+class WizardInvestmentCreation(osv.osv_memory):
 
     _name = 'wizard.generationkwh.investment.creation'
 

--- a/som_generationkwh/wizard/wizard_investment_divest.py
+++ b/som_generationkwh/wizard/wizard_investment_divest.py
@@ -5,7 +5,7 @@ from osv import osv, fields
 from tools.translate import _
 import pickle
 
-class WizardInvestmentDivest(osv.osv):
+class WizardInvestmentDivest(osv.osv_memory):
 
     _name = 'wizard.generationkwh.investment.divest'
 

--- a/som_generationkwh/wizard/wizard_investment_payment.py
+++ b/som_generationkwh/wizard/wizard_investment_payment.py
@@ -5,7 +5,7 @@ from osv import osv, fields
 from tools.translate import _
 import pickle
 
-class WizardInvestmentPayment(osv.osv):
+class WizardInvestmentPayment(osv.osv_memory):
 
     _name = 'wizard.generationkwh.investment.payment'
 

--- a/som_generationkwh/wizard/wizard_investment_transfer.py
+++ b/som_generationkwh/wizard/wizard_investment_transfer.py
@@ -4,7 +4,7 @@ from osv import osv, fields
 from tools.translate import _
 import pickle
 
-class WizardInvestmentTransfer(osv.osv):
+class WizardInvestmentTransfer(osv.osv_memory):
 
     _name = 'wizard.generationkwh.investment.transfer'
 


### PR DESCRIPTION
Heredar de `osv_memory` i no de `osv`. Un cop fet l'_update_, segurament caldrà eliminar les taules a mà (prèvia comprovació de que realment estan buides):

`DROP TABLE wizard_baixa_soci`

https://trello.com/c/j7tPkO6a/19-arreglar-wizards-generation-passar-a-mem%C3%B2ria