### PR TITLE
Add IRPF savings to report data

### DIFF
--- a/som_generationkwh/report/report_amortization_gkwh.py
+++ b/som_generationkwh/report/report_amortization_gkwh.py
@@ -85,6 +85,7 @@ class AccountInvoice(osv.osv):
         report.amortizationDate = dateFormat(mutable_information.amortizationDate)
         report.amortizationNumPayment = mutable_information.amortizationNumber
         report.irpfAmount = irpf_values['irpf_amount']
+        report.irpfSaving = irpf_values['irpf_saving']
         report.previousYear = previous_year
         report.amortValue = amort_value
         return report


### PR DESCRIPTION
Add all Generation KWh savings from last year (`irpf_saving`) to `report` data. It is used in `Generation kWh - Amortització` template and in its attachment.

https://trello.com/c/icQmUcRi/5483-0-0-p10-comunicacions-actualitzar-text-mail-amortitzacions-gkwh
https://trello.com/c/zOfONIEU/5484-0-0-p11-comunicacions-modificar-document-amortitzaci%C3%B3-pr%C3%A8stec-gkwh