### PR TITLE
Canviem el model des d'on es pot imprimir 'Retencions sobre el rendiment de GenerationKWh'

### DIFF
--- a/som_generationkwh/amortization_report.xml
+++ b/som_generationkwh/amortization_report.xml
@@ -44,7 +44,7 @@
             <field eval="0" name="multi"/>
             <field eval="0" name="auto"/>
             <field eval="0" name="header"/>
-            <field name="model">somenergia.soci</field>
+            <field name="model">res.partner</field>
             <field name="type">ir.actions.report.xml</field>
             <field name="name">Retencions sobre el rendiment de GenerationKWh</field>
             <field name="report_webkit">som_generationkwh/report/report_retencions_gkwh.mako</field>


### PR DESCRIPTION
Incidència:
https://secure.helpscout.net/conversation/2204871986/14607460?folderId=7422776

El problema era que el infome està disenyat per llançar-se des del client (partner) en vegada de fer-ho des del soci. El que mostrava era el informe del client que tenia el id del soci. Hi ha lots d'enviament massiu que depenen de que vaja de del client, per tant s'ha modifcat per a que siga des de ahí des d'on s'ha de traure, des de clients.

Ho he modificat de del ERP llevant el botó del informe que actualment estava enllaçat al soci de forma errónea, i l'he tornat a afegir, i com el model ja era el res.partner, ja s'ha creat en el client.

Modifique el codi, per si s'eliminara el informe i es tornara a crear que ja ho faça bé, ja que té NOUPDATE=1