### PR TITLE
Add assignment order endpoint (+ clean unused code)

### DIFF
--- a/som_generationkwh/res_partner.py
+++ b/som_generationkwh/res_partner.py
@@ -57,18 +57,6 @@ class ResPartner(osv.osv):
             for x in Assignments.read(cursor, uid, assignment_ids, [])
         ], key=lambda x: (x['priority'],x['id']))
 
-        def delete_rel(cursor, uid, categ_id, res_partner_id):
-            cursor.execute('delete from res_partner_category_rel where category_id=%s and partner_id=%s',(categ_id, res_partner_id))
-        
-        res_users = self.pool.get('res.users')
-        usuari = res_users.read(cursor, uid, uid, ['name'])['name']
-        old_comment = soci_obj.read(cursor, uid, [member_id], ['comment'])[0]['comment']
-        old_comment = old_comment + '\n' if old_comment else '' 
-        comment =  "{}Baixa efectuada a data {} per: {}".format(old_comment, today, usuari)
-        soci_obj.write(cursor, uid, [member_id], {'baixa': True,
-                                                'data_baixa_soci': today,
-                                                'comment': comment })
-        delete_rel(cursor, uid, soci_category_id, res_partner_id)
 
 
 

--- a/som_generationkwh/tests/partner_tests.py
+++ b/som_generationkwh/tests/partner_tests.py
@@ -3,9 +3,6 @@ from destral import testing
 from destral.transaction import Transaction
 from destral.patch import PatchNewCursors
 from yamlns import namespace as ns
-import netsvc
-import time
-import random
 
 
 class PartnerTests(testing.OOTestCase):


### PR DESCRIPTION
Els Assignments tenen un camp "priority" que marca la prioritat amb la que es reparteix la generació entre diferents contractes.

Fins ara la forma de canviar aquesta prioritat es entrant registre a registre al ERP i canviant els numeros, fent a l'usuaria responsable de no equivocarse i deixar el mateix número dos cops o coses similars (de fet hi ha bastants registres amb prioritats repetides per culpa d'això).

Aquest PR crea una nova funció pensada per ser cridada des de l'Oficina Virtual que rep una llista de assignements i modifica la seva prioritat segons l'ordre en que l'ha rebut. A més a més fa comprovacions de entrada com que tots els assignements siguin del mateix soci o que no se'n deixi cap sense enviar, de manera que assegura que la prioritat quedarà sempre ben posada.

L'únic que modifica aquesta funció és la prioritat, no canvia cap dada més del assignement.