### PR TITLE
Use product generic account

### DIFF
--- a/som_generationkwh/investment_strategy.py
+++ b/som_generationkwh/investment_strategy.py
@@ -832,8 +832,6 @@ class AportacionsActions(InvestmentActions):
             quantity = 1,
             price_unit = to_be_interized,
             product_id = product_id,
-            # partner specific account, was generic from product
-            account_id = account_inv_id,
         )
 
         # Force apply taxes. Taxes from product doesn't work.


### PR DESCRIPTION
## Description

- The account taken from the partner to generate "aportacions" interest invoices was not correct.

## Changes

- Use the product account instead of the partner account.

## Observations

https://secure.helpscout.net/conversation/2306836816/15247629/

## Deploy notes

- To solve another issue, the ID associated with "apo_journal" should be manually changed to 22.

