### PR TITLE
Remove assignements in contract termination

### DIFF
--- a/som_generationkwh/giscedata_polissa.py
+++ b/som_generationkwh/giscedata_polissa.py
@@ -46,6 +46,13 @@ class GiscedataPolissa(osv.osv):
 
         return res
 
+    def wkf_baixa(self, cursor, uid, ids):
+        """Cal dessassignar la polissa de gkwh per deixar les dades consistents"""
+        res = super(GiscedataPolissa, self).wkf_baixa(cursor, uid, ids)
+        assig_obj = self.pool.get('generationkwh.assignment')
+        assigment_ids = assig_obj.search(cursor, uid, [('contract_id', 'in', ids)])
+        assig_obj.unlink(cursor, uid, assigment_ids)
+        return res
 
     _columns = {
         'te_assignacio_gkwh': fields.function(


### PR DESCRIPTION
## Description

Aquesta PR afegeix una funció a l'herencia de giscedata_polissa que en donar de baixa un contracte, l'esborra de qualsevol assignació gkwh on sigui, ja que no te sentit mantenir-ho i creava confussió
