### PR TITLE
We avoid negative savings when we get the total savings over a period of time with IRPF purpose

### DIFF
--- a/som_generationkwh/investment.py
+++ b/som_generationkwh/investment.py
@@ -697,6 +697,7 @@ class GenerationkwhInvestment(osv.osv):
         start_date = str(year) + '-01-01'
         end_date = str(year) + '-12-31'
         total_amount_saving = self.get_total_saving_partner(cursor, uid, partner_id, start_date, end_date)
+        total_amount_saving = 0 if total_amount_saving < 0 else total_amount_saving
         total_data = self.get_total_generation_invoiced_partner(cursor, uid, partner_id, start_date, end_date)
 
         #obtenir total accions inverions

--- a/som_generationkwh/investment.py
+++ b/som_generationkwh/investment.py
@@ -712,11 +712,12 @@ class GenerationkwhInvestment(osv.osv):
         inv_actual = self.read(cursor, uid, investment_id, ['first_effective_date','last_effective_date','nshares'])
         daysharesactual = self.get_dayshares_investmentyear(cursor, uid, inv_actual, start_date, end_date)
         irpf_actual_saving = daysharesactual * total_amount_saving / total_dayshares_year
+        irpf_amout = round((0 if irpf_actual_saving < 0 else irpf_actual_saving)* gkwh.irpfTaxValue, 2)
 
         ret_values = {}
         ret_values['irpf_saving'] = total_amount_saving
         ret_values['irpf_actual_saving'] = round(irpf_actual_saving, 2)
-        ret_values['irpf_amount'] = round(irpf_actual_saving * gkwh.irpfTaxValue, 2)
+        ret_values['irpf_amount'] = irpf_amout
 
         ret_values.update(total_data)
         return ret_values

--- a/som_generationkwh/investment.py
+++ b/som_generationkwh/investment.py
@@ -711,12 +711,12 @@ class GenerationkwhInvestment(osv.osv):
         inv_actual = self.read(cursor, uid, investment_id, ['first_effective_date','last_effective_date','nshares'])
         daysharesactual = self.get_dayshares_investmentyear(cursor, uid, inv_actual, start_date, end_date)
         irpf_actual_saving = daysharesactual * total_amount_saving / total_dayshares_year
-        irpf_amout = round((0 if irpf_actual_saving < 0 else irpf_actual_saving)* gkwh.irpfTaxValue, 2)
+        irpf_amount = round((0 if irpf_actual_saving < 0 else irpf_actual_saving)* gkwh.irpfTaxValue, 2)
 
         ret_values = {}
         ret_values['irpf_saving'] = total_amount_saving
         ret_values['irpf_actual_saving'] = round(irpf_actual_saving, 2)
-        ret_values['irpf_amount'] = irpf_amout
+        ret_values['irpf_amount'] = irpf_amount
 
         ret_values.update(total_data)
         return ret_values

--- a/som_generationkwh/investment.py
+++ b/som_generationkwh/investment.py
@@ -697,7 +697,6 @@ class GenerationkwhInvestment(osv.osv):
         start_date = str(year) + '-01-01'
         end_date = str(year) + '-12-31'
         total_amount_saving = self.get_total_saving_partner(cursor, uid, partner_id, start_date, end_date)
-        total_amount_saving = 0 if total_amount_saving < 0 else total_amount_saving
         total_data = self.get_total_generation_invoiced_partner(cursor, uid, partner_id, start_date, end_date)
 
         #obtenir total accions inverions


### PR DESCRIPTION
## Description
We avoid negative savings when we get the total savings over a period of time with IRPF purpose. This situation can happen when the generation price is greater than the regular tariff.

## Changes
We set total saving to 0 when it's negative

## Observations
https://trello.com/c/vMxUdrJt


