### PR TITLE
Change journal behaviour to remove cash journals and use sales/purchases

### DIFF
--- a/generationkwh/investmentmodel.py
+++ b/generationkwh/investmentmodel.py
@@ -17,6 +17,7 @@ expirationYears = 25 # number of active years for a Gkwh investment
 mandateName = "PRESTEC GENERATION kWh"
 creditorCode = 'ES24000F55091367'
 journalCode = 'GENKWH'
+journalCodeAmor = 'GENKWH_AMOR'
 
 investmentProductCode = 'GENKWH_AE'
 irpfProductCode = 'GENKWH_IRPF'

--- a/som_generationkwh/investment.py
+++ b/som_generationkwh/investment.py
@@ -812,6 +812,12 @@ class GenerationkwhInvestment(osv.osv):
 
         invoice_type, factor = ('out_invoice',-1) if to_be_amortized < irpf_amount else ('in_invoice', 1)
 
+        # The journal
+        journal_code = self.investment_actions(cursor, uid, investment_id).journalCode
+        if invoice_type == 'in_invoice':
+            journal_code = self.investment_actions(cursor, uid, investment_id).purchaseJournalCode
+        journal_id = Journal.search(cursor, uid, [('code', '=', journal_code)])[0]
+
         # The partner
         partner_id = investment.member_id.partner_id.id
         partner = Partner.browse(cursor, uid, partner_id)
@@ -835,11 +841,6 @@ class GenerationkwhInvestment(osv.osv):
 
         product = Product.browse(cursor, uid, product_id)
         product_uom_id = product.uom_id.id
-
-        # The journal
-        journal_id = Journal.search(cursor, uid, [
-            ('code','=',self.investment_actions(cursor, uid, investment_id).journalCode),
-            ])[0]
 
         # The payment type
         if invoice_type == 'out_invoice':
@@ -1764,7 +1765,7 @@ class GenerationkwhInvestment(osv.osv):
         IrModelData = self.pool.get('ir.model.data')
         model, journal_id = IrModelData.get_object_reference(
             cursor, uid,
-            'som_generationkwh', 'genkwh_journal',
+            'som_generationkwh', 'genkwh_amor_journal',
         )
 
         period_data = wizard_period(self, cursor, uid,

--- a/som_generationkwh/investment_strategy.py
+++ b/som_generationkwh/investment_strategy.py
@@ -24,6 +24,10 @@ class InvestmentActions(ErpWrapper):
         pass
 
     @property
+    def purchaseJournalCode(self):
+        pass
+
+    @property
     def productCode(self):
         pass
 
@@ -110,7 +114,7 @@ class InvestmentActions(ErpWrapper):
 
         # The journal
         journal_id = Journal.search(cursor, uid, [
-            ('code','=',self.journalCode),
+            ('code','=',self.purchaseJournalCode),
             ])[0]
 
         # The payment type
@@ -217,6 +221,10 @@ class GenerationkwhActions(InvestmentActions):
     @property
     def journalCode(self):
         return 'GENKWH'
+
+    @property
+    def purchaseJournalCode(self):
+        return 'GENKWH_AMOR'
 
     @property
     def productCode(self):
@@ -508,6 +516,10 @@ class AportacionsActions(InvestmentActions):
     @property
     def journalCode(self):
         return 'APO_FACT'
+
+    @property
+    def purchaseJournalCode(self):
+        return 'APO'
 
     @property
     def productCode(self):

--- a/som_generationkwh/som_generationkwh_data.xml
+++ b/som_generationkwh/som_generationkwh_data.xml
@@ -1361,7 +1361,7 @@
             <field name="user_id" ref="base.user_root"/>
             <field eval="0" name="centralisation"/>
             <field eval="0" name="group_invoice_lines"/>
-            <field name="type">cash</field>
+            <field name="type">sale</field>
             <field name="default_credit_account_id" model="account.account" search="[('code','=','555000000004')]"/>
             <field name="default_debit_account_id" model="account.account" search="[('code','=','555000000004')]"/>
             <field name="view_id" ref="account.account_journal_bank_view"/>
@@ -1370,6 +1370,24 @@
             <field eval="1" name="active"/>
             <field eval="1" name="update_posted"/>
             <field name="name">Factures GenerationkWh</field>
+            <field eval="0" name="refund_journal"/>
+            <field eval="1" name="entry_posted"/>
+        </record>
+        <record id="genkwh_amor_journal" model="account.journal">
+            <field name="code">GENKWH_AMOR</field>
+            <field eval="[(6,0,[])]" name="account_control_ids"/>
+            <field name="user_id" ref="base.user_root"/>
+            <field eval="0" name="centralisation"/>
+            <field eval="0" name="group_invoice_lines"/>
+            <field name="type">purchase</field>
+            <field name="default_credit_account_id" model="account.account" search="[('code','=','662000000001')]"/>
+            <field name="default_debit_account_id" model="account.account" search="[('code','=','662000000001')]"/>
+            <field name="view_id" ref="account.account_journal_bank_view"/>
+            <field eval="[(6,0,[])]" name="type_control_ids"/>
+            <field name="sequence_id" ref="account.sequence_journal"/>
+            <field eval="1" name="active"/>
+            <field eval="1" name="update_posted"/>
+            <field name="name">Amortització GenerationkWh</field>
             <field eval="0" name="refund_journal"/>
             <field eval="1" name="entry_posted"/>
         </record>
@@ -2024,9 +2042,9 @@ ${text_legal}
             <field name="user_id" ref="base.user_root"/>
             <field eval="0" name="centralisation"/>
             <field eval="0" name="group_invoice_lines"/>
-            <field name="type">cash</field>
-            <field name="default_credit_account_id" ref="pgc_555000000011" />
-            <field name="default_debit_account_id" ref="pgc_555000000011" />
+            <field name="type">purchase</field>
+            <field name="default_credit_account_id" model="account.account" search="[('code','=','662000000001')]"/>
+            <field name="default_debit_account_id" model="account.account" search="[('code','=','662000000001')]"/>
             <field name="view_id" ref="account.account_journal_bank_view"/>
             <field eval="[(6,0,[])]" name="type_control_ids"/>
             <field name="sequence_id" ref="account.sequence_journal"/>
@@ -2042,7 +2060,7 @@ ${text_legal}
             <field name="user_id" ref="base.user_root"/>
             <field eval="0" name="centralisation"/>
             <field eval="0" name="group_invoice_lines"/>
-            <field name="type">cash</field>
+            <field name="type">sale</field>
             <field name="default_credit_account_id" ref="pgc_555000000011" />
             <field name="default_debit_account_id" ref="pgc_555000000011" />
             <field name="view_id" ref="account.account_journal_bank_view"/>

--- a/som_generationkwh/som_generationkwh_data.xml
+++ b/som_generationkwh/som_generationkwh_data.xml
@@ -1380,8 +1380,8 @@
             <field eval="0" name="centralisation"/>
             <field eval="0" name="group_invoice_lines"/>
             <field name="type">purchase</field>
-            <field name="default_credit_account_id" model="account.account" search="[('code','=','662000000001')]"/>
-            <field name="default_debit_account_id" model="account.account" search="[('code','=','662000000001')]"/>
+            <field name="default_credit_account_id" model="account.account" search="[('code','=','163500000000')]"/>
+            <field name="default_debit_account_id" model="account.account" search="[('code','=','163500000000')]"/>
             <field name="view_id" ref="account.account_journal_bank_view"/>
             <field eval="[(6,0,[])]" name="type_control_ids"/>
             <field name="sequence_id" ref="account.sequence_journal"/>
@@ -2177,7 +2177,7 @@ ${text_legal}
             <field name="expiration_years">0</field>
             <field name="waiting_days">0</field>
             <field name="mandate_name">PRESTEC Aportacions</field>
-            <field name="journal_id" ref="apo_journal"/>
+            <field name="journal_id" ref="apo_fact_journal"/>
             <field name="investment_product_id" ref="apo_product_ae" />
             <field name="investment_payment_mode_id" ref="apo_investment_payment_mode"/>
         </record>
@@ -2193,7 +2193,7 @@ ${text_legal}
             <field name="expiration_years">0</field>
             <field name="waiting_days">0</field>
             <field name="mandate_name">PRESTEC Aportacions</field>
-            <field name="journal_id" ref="apo_journal"/>
+            <field name="journal_id" ref="apo_fact_journal"/>
             <field name="investment_product_id" ref="apo_product_ae" />
             <field name="investment_payment_mode_id" ref="apo_investment_payment_mode"/>
         </record>
@@ -2209,7 +2209,7 @@ ${text_legal}
             <field name="expiration_years">0</field>
             <field name="waiting_days">0</field>
             <field name="mandate_name">PRESTEC Aportacions</field>
-            <field name="journal_id" ref="apo_journal"/>
+            <field name="journal_id" ref="apo_fact_journal"/>
             <field name="investment_product_id" ref="apo_product_ae" />
             <field name="investment_payment_mode_id" ref="apo_investment_payment_mode"/>
         </record>

--- a/som_generationkwh/tests/investment_tests.py
+++ b/som_generationkwh/tests/investment_tests.py
@@ -1977,7 +1977,7 @@ class InvestmentTests(testing.OOTestCase):
                   quantity: 1.0
                   product_id: '[GENKWH_AMOR] Amortització Generation kWh'
                   invoice_line_tax_id: []
-                journal_id: Factures GenerationkWh
+                journal_id: Amortització GenerationkWh
                 mandate_id: {mandate_id}
                 name: {investment_name}-DES
                 number: {investment_name}-DES
@@ -2087,7 +2087,7 @@ class InvestmentTests(testing.OOTestCase):
                   product_id: '[GENKWH_IRPF] Retenció IRPF estalvi Generation kWh'
                   quantity: 1.0
                   uos_id: PCE
-                journal_id: Factures GenerationkWh
+                journal_id: Amortització GenerationkWh
                 mandate_id: {mandate_id}
                 name: {investment_name}-DES
                 number: {investment_name}-DES
@@ -2220,7 +2220,7 @@ class InvestmentTests(testing.OOTestCase):
                   product_id: '[GENKWH_IRPF] Retenció IRPF estalvi Generation kWh'
                   quantity: 1.0
                   uos_id: PCE
-                journal_id: Factures GenerationkWh
+                journal_id: Amortització GenerationkWh
                 mandate_id: {mandate_id}
                 name: {investment_name}-DES
                 number: {investment_name}-DES
@@ -2357,7 +2357,7 @@ class InvestmentTests(testing.OOTestCase):
                   product_id: '[GENKWH_IRPF] Retenció IRPF estalvi Generation kWh'
                   quantity: 1.0
                   uos_id: PCE
-                journal_id: Factures GenerationkWh
+                journal_id: Amortització GenerationkWh
                 mandate_id: {mandate_id}
                 name: {investment_name}-DES
                 number: {investment_name}-DES
@@ -2446,7 +2446,7 @@ class InvestmentTests(testing.OOTestCase):
                   quantity: 1.0
                   product_id: '[APO_AE] Aportacions'
                   invoice_line_tax_id: []
-                journal_id: Factures Aportacions
+                journal_id: Factures Liquidació Aportacions
                 mandate_id: {mandate_id}
                 name: {investment_name}-DES
                 number: {investment_name}-DES

--- a/som_generationkwh/tests/partner_tests.py
+++ b/som_generationkwh/tests/partner_tests.py
@@ -346,7 +346,7 @@ class PartnerTests(testing.OOTestCase):
 
             remaining = self.partner_obj.www_hourly_remaining_generationkwh(cursor, uid, partner_id)
 
-            self.assertEqual(len(remaining), 8431)
+            self.assertEqual(len(remaining), 8783)
             self.assertEqual(sum(remaining.values()), 0)
 
     def test__www_hourly_rights_generationkwh(self):


### PR DESCRIPTION
https://trello.com/c/zYWCYmkG/271-arreglar-diaris-comptables-tipus-de-diari

A la nova versió del ERP es comprova que els diaris siguin coherents amb les factures, per tant una factura de sortida ha d'anar a un diari de ventes i una d'entrada a un diari de compres.

Aquest PR treu els diaris de caixa que hi havia a generation i els desdobla, i adapta el codi perque faci servir el corresponent segons toqui.

A tenir en compte per revisar: els moviments contables poden portar qualsevol diari, ja que aquesta comprovació no afecta, i ens han confirmat desde l'ET que no els importa.

Com el XML està amb no_update, **s'haurà de fer a mà el següent:**
- Canviar el xml_id de APO ( apo_journal ) del 67 al 22
- Executar: `update generationkwh_emission set journal_id = 68 where journal_id = 67;`
- Executar: `update payment_mode set journal = 22 where journal = 67;`
- Esborrar el APO que no serveix (el 67)
- Posar a mà el diari GENKWH a tipus sale