### PR TITLE
Fix partner tests (make them always pass)

### DIFF
--- a/som_generationkwh/tests/partner_tests.py
+++ b/som_generationkwh/tests/partner_tests.py
@@ -382,7 +382,7 @@ class PartnerTests(testing.OOTestCase):
             {'date': 1706486400000, 'value': 1},
             {'date': 1706490000000, 'value': 2},
         ]
-        self.assertEqual(
+        self.assertItemsEqual(
             self.partner_obj._prepare_datetime_value_www_response(original),
             expected
         )


### PR DESCRIPTION
## Description

Tests where failing here (not in local) because dict travesial order is not deterministic... with this change the test will pass (I hope)

