### PR TITLE
Remove www_som dependence (now www_fields are in base_extended_som)

### DIFF
--- a/som_generationkwh/__terp__.py
+++ b/som_generationkwh/__terp__.py
@@ -20,7 +20,6 @@
     'som_partner_account',
     'giscedata_signatura_documents_signaturit',
     'account_invoice_som',
-    'www_som',
     'c2c_webkit_report',
     'async_reports',
     'custom_search',


### PR DESCRIPTION
## Description

res_partner www_fields are now in base_extended_som, this PR removes www_som dependence to avoid circular dependencies problems (to be applied at the same time with https://github.com/Som-Energia/openerp_som_addons/pull/599 )

