### PR TITLE
Get generation montlhy and yearly historical use

### DIFF
--- a/som_generationkwh/assignment.py
+++ b/som_generationkwh/assignment.py
@@ -505,9 +505,8 @@ class GenerationkWhAssignment(osv.osv):
             line = gkwh_line.factura_line_id
             contract = invoice.polissa_id
             multiplier = 1 if invoice.type in ('out_invoice', 'in_refund') else -1
-            response[str(contract.id)]['number'] = contract.name
-            response[str(contract.id)]['address'] = contract.cups_direccio
-            response[str(contract.id)][str(line.product_id.name)] += (
+            response[str(contract.name)]['address'] = contract.cups_direccio
+            response[str(contract.name)][str(line.product_id.name)] += (
                 line.quantity*multiplier)
 
         # clean defaultdict for serialization

--- a/som_generationkwh/assignment.py
+++ b/som_generationkwh/assignment.py
@@ -468,49 +468,46 @@ class GenerationkWhAssignment(osv.osv):
         result = [ id for id, in cursor.fetchall() ]
         return result
 
-    def get_generationkwh_monthly_use(self, cursor, uid, assignment_ids, month):
+    def get_generationkwh_monthly_use(self, cursor, uid, res_partner_id, month):
         """Month must be in the format YYYY-MM"""
         month_start = datetime.datetime.strptime(month, '%Y-%m')
         next_month = month_start+relativedelta(months=1)
         date_domain = [
-            ('date_invoice', '>=', month_start.strftime('%Y-%m-%d')),
-            ('date_invoice', '<', next_month.strftime('%Y-%m-%d'))
+            ('factura_id.date_invoice', '>=', month_start.strftime('%Y-%m-%d')),
+            ('factura_id.date_invoice', '<', next_month.strftime('%Y-%m-%d'))
         ]
-        return self._get_generationkwh_use(cursor, uid, assignment_ids, date_domain)
+        return self._get_generationkwh_use(cursor, uid, res_partner_id, date_domain)
 
 
-    def get_generationkwh_yearly_use(self, cursor, uid, assignment_ids, year):
+    def get_generationkwh_yearly_use(self, cursor, uid, res_partner_id, year):
         """Year must be in the format YYYY"""
         year_start = datetime.datetime.strptime(year, '%Y')
         next_year = year_start+relativedelta(years=1)
         date_domain = [
-            ('date_invoice', '>=', year_start.strftime('%Y-%m-%d')),
-            ('date_invoice', '<', next_year.strftime('%Y-%m-%d'))
+            ('factura_id.date_invoice', '>=', year_start.strftime('%Y-%m-%d')),
+            ('factura_id.date_invoice', '<', next_year.strftime('%Y-%m-%d'))
         ]
-        return self._get_generationkwh_use(cursor, uid, assignment_ids, date_domain)
+        return self._get_generationkwh_use(cursor, uid, res_partner_id, date_domain)
 
-    def _get_generationkwh_use(self, cursor, uid, assignment_ids, date_domain):
-        GisceInvoice = self.pool.get('giscedata.facturacio.factura')
+    def _get_generationkwh_use(self, cursor, uid, res_partner_id, date_domain):
         GenerationkWhInvoiceLineOwner = self.pool.get('generationkwh.invoice.line.owner')
 
-        response = {}
-        for assignment in self.browse(cursor, uid, assignment_ids):
-            gisce_invoice_ids = GisceInvoice.search(cursor, uid, date_domain+[
-                ('polissa_id', '=', assignment.contract_id.id)])
-            generation_line_ids = GenerationkWhInvoiceLineOwner.search(cursor, uid, [
-                ('factura_id', 'in', gisce_invoice_ids)])
-            generation_lines = GenerationkWhInvoiceLineOwner.browse(
-                cursor, uid, generation_line_ids)
+        generation_line_ids = GenerationkWhInvoiceLineOwner.search(
+                cursor, uid, [('owner_id', '=', res_partner_id)]+date_domain)
 
-            response[str(assignment.id)] = defaultdict(int)
-            for generation_line in generation_lines:
-                invoice = generation_line.factura_id
-                line = generation_line.factura_line_id
-                multiplier = 1 if invoice.type in ('out_invoice', 'in_refund') else -1
-                response[str(assignment.id)][str(line.product_id.name)] += (
-                    line.quantity*multiplier)
-            response[str(assignment.id)] = dict(response[str(assignment.id)])
+        response = defaultdict(lambda: defaultdict(int))
+        for gkwh_line in GenerationkWhInvoiceLineOwner.browse(cursor, uid, generation_line_ids):
+            invoice = gkwh_line.factura_id
+            line = gkwh_line.factura_line_id
+            contract = invoice.polissa_id
+            multiplier = 1 if invoice.type in ('out_invoice', 'in_refund') else -1
+            response[str(contract.id)]['number'] = contract.name
+            response[str(contract.id)]['address'] = contract.cups_direccio
+            response[str(contract.id)][str(line.product_id.name)] += (
+                line.quantity*multiplier)
 
+        # clean defaultdict for serialization
+        response = {k: dict(v) for k, v in response.items()}
         return response
 
 

--- a/som_generationkwh/tests/__init__.py
+++ b/som_generationkwh/tests/__init__.py
@@ -1,5 +1,6 @@
 from emission_tests import *
 from investment_tests import *
+from assignment_tests import *
 from partner_tests import *
 from somenergia_soci_tests import *
 from test_wizard_baixa_soci import *

--- a/som_generationkwh/tests/assignment_tests.py
+++ b/som_generationkwh/tests/assignment_tests.py
@@ -28,11 +28,8 @@ class AssignmentTests(testing.OOTestCase):
             partner_id = self.IrModelData.get_object_reference(
                 cursor, uid, 'som_generationkwh', 'res_partner_inversor1'
             )[1]
-            contract_id = self.IrModelData.get_object_reference(
-                cursor, uid, 'giscedata_polissa', 'polissa_0001'
-            )[1]
             result = self.Assignement.get_generationkwh_monthly_use(cursor, uid, partner_id, '2016-03')
-            self.assertEqual(result[str(contract_id)]['P1'], 1)
+            self.assertEqual(result['0001C']['P1'], 1)
 
     def test__get_generationkwh_yearly_use(self):
         with Transaction().start(self.database) as txn:
@@ -41,11 +38,8 @@ class AssignmentTests(testing.OOTestCase):
             partner_id = self.IrModelData.get_object_reference(
                 cursor, uid, 'som_generationkwh', 'res_partner_inversor1'
             )[1]
-            contract_id = self.IrModelData.get_object_reference(
-                cursor, uid, 'giscedata_polissa', 'polissa_0001'
-            )[1]
             result = self.Assignement.get_generationkwh_yearly_use(cursor, uid, partner_id, '2016')
-            self.assertEqual(result[str(contract_id)]['P1'], 1)
+            self.assertEqual(result['0001C']['P1'], 1)
 
     def test__get_generationkwh_use_contract_data(self):
         with Transaction().start(self.database) as txn:
@@ -54,9 +48,5 @@ class AssignmentTests(testing.OOTestCase):
             partner_id = self.IrModelData.get_object_reference(
                 cursor, uid, 'som_generationkwh', 'res_partner_inversor1'
             )[1]
-            contract_id = self.IrModelData.get_object_reference(
-                cursor, uid, 'giscedata_polissa', 'polissa_0001'
-            )[1]
             result = self.Assignement.get_generationkwh_yearly_use(cursor, uid, partner_id, '2016')
-            self.assertEqual(result[str(contract_id)]['number'], '0001C')
-            self.assertIn("carrer inventat", result[str(contract_id)]['address'])
+            self.assertIn("carrer inventat", result['0001C']['address'])

--- a/som_generationkwh/tests/assignment_tests.py
+++ b/som_generationkwh/tests/assignment_tests.py
@@ -15,28 +15,48 @@ class AssignmentTests(testing.OOTestCase):
         with Transaction().start(self.database) as txn:
             cursor = txn.cursor
             uid = txn.user
-            assignment_id = self.IrModelData.get_object_reference(
-                cursor, uid, 'som_generationkwh', 'assignment_0001'
+            partner_id = self.IrModelData.get_object_reference(
+                cursor, uid, 'som_generationkwh', 'res_partner_inversor1'
             )[1]
-            result = self.Assignement.get_generationkwh_monthly_use(cursor, uid, [assignment_id], '1990-08')
-            self.assertEqual(result, {str(assignment_id): {}})
+            result = self.Assignement.get_generationkwh_monthly_use(cursor, uid, partner_id, '1990-08')
+            self.assertEqual(result, {})
 
     def test__get_generationkwh_monthly_use(self):
         with Transaction().start(self.database) as txn:
             cursor = txn.cursor
             uid = txn.user
-            assignment_id = self.IrModelData.get_object_reference(
-                cursor, uid, 'som_generationkwh', 'assignment_0001'
+            partner_id = self.IrModelData.get_object_reference(
+                cursor, uid, 'som_generationkwh', 'res_partner_inversor1'
             )[1]
-            result = self.Assignement.get_generationkwh_monthly_use(cursor, uid, [assignment_id], '2016-03')
-            self.assertEqual(result[str(assignment_id)]['P1'], 1)
+            contract_id = self.IrModelData.get_object_reference(
+                cursor, uid, 'giscedata_polissa', 'polissa_0001'
+            )[1]
+            result = self.Assignement.get_generationkwh_monthly_use(cursor, uid, partner_id, '2016-03')
+            self.assertEqual(result[str(contract_id)]['P1'], 1)
 
     def test__get_generationkwh_yearly_use(self):
         with Transaction().start(self.database) as txn:
             cursor = txn.cursor
             uid = txn.user
-            assignment_id = self.IrModelData.get_object_reference(
-                cursor, uid, 'som_generationkwh', 'assignment_0001'
+            partner_id = self.IrModelData.get_object_reference(
+                cursor, uid, 'som_generationkwh', 'res_partner_inversor1'
             )[1]
-            result = self.Assignement.get_generationkwh_yearly_use(cursor, uid, [assignment_id], '2016')
-            self.assertEqual(result[str(assignment_id)]['P1'], 1)
+            contract_id = self.IrModelData.get_object_reference(
+                cursor, uid, 'giscedata_polissa', 'polissa_0001'
+            )[1]
+            result = self.Assignement.get_generationkwh_yearly_use(cursor, uid, partner_id, '2016')
+            self.assertEqual(result[str(contract_id)]['P1'], 1)
+
+    def test__get_generationkwh_use_contract_data(self):
+        with Transaction().start(self.database) as txn:
+            cursor = txn.cursor
+            uid = txn.user
+            partner_id = self.IrModelData.get_object_reference(
+                cursor, uid, 'som_generationkwh', 'res_partner_inversor1'
+            )[1]
+            contract_id = self.IrModelData.get_object_reference(
+                cursor, uid, 'giscedata_polissa', 'polissa_0001'
+            )[1]
+            result = self.Assignement.get_generationkwh_yearly_use(cursor, uid, partner_id, '2016')
+            self.assertEqual(result[str(contract_id)]['number'], '0001C')
+            self.assertIn("carrer inventat", result[str(contract_id)]['address'])


### PR DESCRIPTION
Fins ara el ús de generation (mensual o anual) es feia segons les assignacions.

Com es vol veure també l'historic i per tant veure dades de contractes que ja no estan assignats, es canvia aquesta part de logica de negoci perque en comptes de funcionar per aportacions, donat un partner i un periode, busca les seves linies de generation a factura i des d'alla aconsegueix l'us, sent independent de les assignacions actuals.

També retorna info bàsica del contracte que el frontal necessita ensenyar (num contracte i adreça), ja que al poder portar coses antigues, potencialment no estarà a la cache de la OV.

Aquest PR s'ha de deployar conjuntament amb canvis a la OV: https://github.com/Som-Energia/oficinavirtual/pull/100