### PR TITLE
Fix use for titular, not the rights partner

### DIFF
--- a/som_generationkwh/assignment.py
+++ b/som_generationkwh/assignment.py
@@ -494,7 +494,7 @@ class GenerationkWhAssignment(osv.osv):
         GenerationkWhInvoiceLineOwner = self.pool.get('generationkwh.invoice.line.owner')
         q = OOQuery(GenerationkWhInvoiceLineOwner, cursor, uid)
 
-        sql = q.select(['id']).where([('owner_id.id', '=', res_partner_id)]+date_domain)
+        sql = q.select(['id']).where([('factura_id.polissa_id.titular.id', '=', res_partner_id)]+date_domain)
         cursor.execute(*sql)
         res = cursor.fetchall()
         generation_line_ids = [line[0] for line in res]


### PR DESCRIPTION
## Description

This PR fix the filter for the use methods (year and monthly), getting the use from the titular instead of the rights partner



