### PR TITLE
Sending withholding tax certificates 2024

### DIFF
--- a/som_generationkwh/report/report_retencions_gkwh.mako
+++ b/som_generationkwh/report/report_retencions_gkwh.mako
@@ -214,7 +214,7 @@
       </div>
       <div class="CaixaDadesAportacio">
         <p class="ContingutDades"><b>${_(u"Estalvi:")}</b> ${formatLang(data.estalvi, monetary=True)} €<br>
-        <b>${_(u"19% Retenció sobre l'estalvi:")}</b> ${formatLang(data.retencio, monetary=True)} €<br>
+        <b>${_(u"19% IRPF:")}</b> ${formatLang(data.retencio, monetary=True)} €<br>
         <b>${_(u"Tipus percepció:")}</b> ${_(u"Guany en espècie")}</p>
       </div>
     </div>

--- a/som_generationkwh/report/report_retencions_gkwh.mako
+++ b/som_generationkwh/report/report_retencions_gkwh.mako
@@ -3,7 +3,7 @@
     import logging
     logger = logging.getLogger('openerp')
     report = objects[0]
-    data = report.generationkwh_amortization_data()
+    data = report.report_retencions_data(is_generationkwh=True)
 %>
 
 <html>
@@ -157,8 +157,8 @@
     <div class="LogoPpal">
       <a href="https://www.somenergia.coop" target="_blank">
         <img src="${addons_path}/som_inversions/report/logo.jpg" width="150" height="150"/ alt="Logo Som Energia"></a><br>
-      <p class="sotalogo"><b>${data.partner_name}</b><br>${_(u"CIF:")} ${data.partner_vat.replace('ES','')}<br>${_(u"Domicili:")} ${data.address_street} ${data.address_zip} - ${data.address_city}<br>
-        ${_(u"Adreça electrònica:")} ${data.address_email}
+      <p class="sotalogo"><b>${data.somenergia.partner_name}</b><br>${_(u"CIF:")} ${data.somenergia.partner_vat.replace('ES','')}<br>${_(u"Domicili:")} ${data.somenergia.address_street} ${data.somenergia.address_zip} - ${data.somenergia.address_city}<br>
+        ${_(u"Adreça electrònica:")} generationkwh@somenergia.coop
     </div>
   </div>
   <div class="TitolHeader">
@@ -213,8 +213,8 @@
       <div class="CaixaEspai">
       </div>
       <div class="CaixaDadesAportacio">
-        <p class="ContingutDades"><b>${_(u"Estalvi:")}</b> ${formatLang(data.estalvi, monetary=True)} €<br>
-        <b>${_(u"19% IRPF:")}</b> ${formatLang(data.retencio, monetary=True)} €<br>
+        <p class="ContingutDades"><b>${_(u"Estalvi:")}</b> ${formatLang(data.amount_untaxed, monetary=True)} €<br>
+        <b>${_(u"19% IRPF:")}</b> ${formatLang(data.amount_tax, monetary=True)} €<br>
         <b>${_(u"Tipus percepció:")}</b> ${_(u"Guany en espècie")}</p>
       </div>
     </div>

--- a/som_generationkwh/report/report_retencions_gkwh.mako
+++ b/som_generationkwh/report/report_retencions_gkwh.mako
@@ -207,7 +207,7 @@
     </div>
     <div class="fila">
       <div class="CaixaDadesTitular">
-        <p class="ContingutDades"><b>${_(u"Nom:")}</b> ${data.member_name}<br><b>${_(u"NIF/NIE:")}</b> ${data.member_vat}
+        <p class="ContingutDades"><b>${_(u"Nom:")}</b> ${data.partner_name}<br><b>${_(u"NIF/NIE:")}</b> ${data.partner_vat}
         </p>
       </div>
       <div class="CaixaEspai">

--- a/som_generationkwh/report/report_retencions_gkwh.py
+++ b/som_generationkwh/report/report_retencions_gkwh.py
@@ -14,7 +14,7 @@ class ResPartner(osv.osv):
     _name = 'res.partner'
     _inherit = 'res.partner'
 
-    def generationkwh_amortization_data(self, cursor, uid, ids):
+    def generationkwh_amortization_data_unused(self, cursor, uid, ids):
         if not ids:
             raise Exception("No member provided")
 


### PR DESCRIPTION
## Description
We realize that 'Retenció sobre el rendiment Generationkwh' report recomputes amounts that have been previously computed and registered in the corresponding model193. This model has the real data that must be shown in the report. We reuse the function used in a very similar report 'Liquidacions - Certificats retencions aportacions' in the same way, getting the data from the registers of the corresponding model193. This way is more reliable.

## Requested on
https://somenergia.openproject.com/wp/789

## Depens on this PR
https://github.com/Som-Energia/openerp_som_addons/pull/855

## Checks
- [x] Reiniciar serveis


