### PR TITLE
Change HolidayProvider implementation to use enerdata

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ plantmeter
 python-dateutil
 decorator
 babel
+enerdata>=1.1.0

--- a/som_generationkwh/holidays.py
+++ b/som_generationkwh/holidays.py
@@ -2,25 +2,31 @@
 
 from .erpwrapper import ErpWrapper
 from osv import osv, fields
-from generationkwh.isodates import isodate
+from enerdata.calendars import REECalendar
+from datetime import timedelta
 
 class HolidaysProvider(ErpWrapper):
+    # Now it don't use anything from ERP, but we keep the mother class
+    # and parameters to don't break the interface.
+
+    def __init__(self, erp, cursor, uid, context=None):
+        super(HolidaysProvider, self).__init__(erp, cursor, uid, context)
+        self.cal = REECalendar()
 
     def get(self, start, stop):
         """Returns the holidays to be considering by fares
         between start and stop date including both.
         """
+        holidays = []
 
-        Holidays = self.erp.pool.get('giscedata.dfestius')
-        ids = Holidays.search(self.cursor, self.uid, [
-            ('name', '>=', start),
-            ('name', '<=', stop),
-            ], 0,None,'name desc',self.context)
-        return [
-            isodate(h['name'])
-            for h in Holidays.read(self.cursor, self.uid,
-                ids, ['name'], self.context)
-            ]
+        day = start
+        while day <= stop:
+            if self.cal.is_holiday(day):
+                holidays.append(day)
+            day += timedelta(days=1)
+
+        return holidays
+
 
 class GenerationkWhHolidaysTestHelper(osv.osv):
     """

--- a/som_generationkwh/tests/fareperiodcurve_tests.py
+++ b/som_generationkwh/tests/fareperiodcurve_tests.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from generationkwh.fareperiodcurve import FarePeriodCurve, libfacturacioatr
+from som_generationkwh.holidays import HolidaysProvider
 from destral import testing
 from destral.transaction import Transaction
 from yamlns import namespace as ns
@@ -19,7 +20,7 @@ class HolidaysProvidersMockup(object):
         self.set(holidays)
 
 
-class FarePeriodCurveTests(testing.OOTestCaseWithCursor):
+class FarePeriodCurveTests(testing.OOTestCase):
 
     from yamlns.testutils import assertNsEqual
 
@@ -444,5 +445,30 @@ class FarePeriodCurveTests(testing.OOTestCaseWithCursor):
             (datetime.date(2021,6,1), datetime.date(2022,5,31)),
                 ]
         self.assertEqual(result, expected)
+
+    def test_holidaysProvider__implementation(self):
+        """
+        Test that the holidays provider mockup works as expected.
+        """
+        with Transaction().start(self.database) as txn:
+            cursor = txn.cursor
+            uid = txn.user
+
+            holidays_provider = HolidaysProvider(self.openerp, cursor, uid)
+            holidays = holidays_provider.get(datetime.date(2024, 8, 15), datetime.date(2025, 5, 1))
+            self.assertEqual(
+                holidays,
+                [
+                    isodate('2024-08-15'),
+                    isodate('2024-10-12'),
+                    isodate('2024-11-01'),
+                    isodate('2024-12-06'),
+                    isodate('2024-12-08'),
+                    isodate('2024-12-25'),
+                    isodate('2025-01-01'),
+                    isodate('2025-01-06'),
+                    isodate('2025-05-01'),
+                ]
+            )
 
 # vim: et ts=4 sw=4


### PR DESCRIPTION
## Description

La taula `giscedata.dfestius` fa anys que no s'actualitza, ara GISCE fa servir el REECalendar de enerdata per saber els festius.

Aquest PR actualitza Generation per fer servir el mateix, i afegeix un test que comprova que aquesta implementació funciona com l'anterior.
