### PR TITLE
🐛 Afegir l'amortitzat al calcul total de l'invertit

### DIFF
--- a/som_generationkwh/investment.py
+++ b/som_generationkwh/investment.py
@@ -304,7 +304,8 @@ class GenerationkwhInvestment(osv.osv):
         amount = 0
 
         for id in investment_ids:
-            amount += self.read(cursor, uid, id, ['nshares'])['nshares'] * gkwh.shareValue
+            inv_data = self.read(cursor, uid, id, ['nshares', 'amortized_amount'])
+            amount += (inv_data['nshares'] * gkwh.shareValue) - inv_data['amortized_amount']
 
         return amount
 


### PR DESCRIPTION
## Descripció

La funció get_investments_amount no té en compte la part amortitzada de cada registre, per tant el valor retornat no té en comte registres total o parcialment amortitzats donant problemes amb la funció get_max_investment.

Incidència: https://freescout.somenergia.coop/conversation/8054059?folder_id=69
